### PR TITLE
feat: improve CLI output, relative paths, and example configs

### DIFF
--- a/examples/node-express/bugatti.config.toml
+++ b/examples/node-express/bugatti.config.toml
@@ -1,8 +1,9 @@
 # Node/Express example — install deps then start the server.
 
 [provider]
-extra_system_prompt = "This is an Express.js TypeScript app. Use the browser (headed `agent-browser`) for UI tests (record a video to include in the run artifacts). Use curl or fetch for API tests."
+
 base_url = "http://localhost:3111"
+extra_system_prompt = "This is an Express.js TypeScript app. Use a headed browser (using `agent-browser` skill and record a video of the test run into the run artifacts) for UI tests. Use curl or fetch for API tests."
 agent_args = [
     "--dangerously-skip-permissions",
     "--no-session-persistence",

--- a/examples/python-flask/bugatti.config.toml
+++ b/examples/python-flask/bugatti.config.toml
@@ -2,8 +2,20 @@
 
 [provider]
 strict_warnings = true
+extra_system_prompt = "This is a Python Flask app. Use a headed browser (using `agent-browser` skill and record a video of the test run into the run artifacts) for UI tests. Use curl or fetch for API tests."
 base_url = "http://localhost:5111"
-agent_args = ["--dangerously-skip-permissions"]
+agent_args = [
+    "--dangerously-skip-permissions",
+    "--no-session-persistence",
+    "--model",
+    "haiku",
+    "--effort",
+    "medium",
+]
+
+[commands.install]
+kind = "short_lived"
+cmd = "pip3 install -r requirements.txt"
 
 [commands.server]
 kind = "long_lived"

--- a/examples/rust-cli/CLAUDE.md
+++ b/examples/rust-cli/CLAUDE.md
@@ -1,0 +1,8 @@
+This is a simple Rust CLI called `greeter`.
+
+After `cargo build`, the binary is at `./target/debug/greeter`.
+
+Usage:
+- `./target/debug/greeter` — prints usage to stderr, exits 1
+- `./target/debug/greeter <name>` — prints "Hello, <name>!"
+- `./target/debug/greeter <name> --shout` — prints "HELLO, <NAME>!"

--- a/examples/rust-cli/bugatti.config.toml
+++ b/examples/rust-cli/bugatti.config.toml
@@ -2,7 +2,14 @@
 
 [provider]
 step_timeout_secs = 120
-agent_args = ["--dangerously-skip-permissions"]
+agent_args = [
+    "--dangerously-skip-permissions",
+    "--no-session-persistence",
+    "--model",
+    "haiku",
+    "--effort",
+    "medium",
+]
 
 [commands.build]
 kind = "short_lived"

--- a/examples/static-html/bugatti.config.toml
+++ b/examples/static-html/bugatti.config.toml
@@ -2,5 +2,12 @@
 # The agent opens index.html directly in the browser.
 
 [provider]
-extra_system_prompt = "Use the browser to open and interact with the local HTML file."
-agent_args = ["--dangerously-skip-permissions"]
+extra_system_prompt = "Use a headed browser (using `agent-browser` skill and record a video of the test run into the run artifacts) for UI tests."
+agent_args = [
+    "--dangerously-skip-permissions",
+    "--no-session-persistence",
+    "--model",
+    "haiku",
+    "--effort",
+    "medium",
+]

--- a/scripts/ralph/CLAUDE.md
+++ b/scripts/ralph/CLAUDE.md
@@ -1,0 +1,104 @@
+# Ralph Agent Instructions
+
+You are an autonomous coding agent working on a software project.
+
+## Your Task
+
+1. Read the PRD at `prd.json` (in the same directory as this file)
+2. Read the progress log at `progress.txt` (check Codebase Patterns section first)
+3. Check you're on the correct branch from PRD `branchName`. If not, check it out or create from main.
+4. Pick the **highest priority** user story where `passes: false`
+5. Implement that single user story
+6. Run quality checks (e.g., typecheck, lint, test - use whatever your project requires)
+7. Update CLAUDE.md files if you discover reusable patterns (see below)
+8. If checks pass, commit ALL changes with message: `feat: [Story ID] - [Story Title]`
+9. Update the PRD to set `passes: true` for the completed story
+10. Append your progress to `progress.txt`
+
+## Progress Report Format
+
+APPEND to progress.txt (never replace, always append):
+```
+## [Date/Time] - [Story ID]
+- What was implemented
+- Files changed
+- **Learnings for future iterations:**
+  - Patterns discovered (e.g., "this codebase uses X for Y")
+  - Gotchas encountered (e.g., "don't forget to update Z when changing W")
+  - Useful context (e.g., "the evaluation panel is in component X")
+---
+```
+
+The learnings section is critical - it helps future iterations avoid repeating mistakes and understand the codebase better.
+
+## Consolidate Patterns
+
+If you discover a **reusable pattern** that future iterations should know, add it to the `## Codebase Patterns` section at the TOP of progress.txt (create it if it doesn't exist). This section should consolidate the most important learnings:
+
+```
+## Codebase Patterns
+- Example: Use `sql<number>` template for aggregations
+- Example: Always use `IF NOT EXISTS` for migrations
+- Example: Export types from actions.ts for UI components
+```
+
+Only add patterns that are **general and reusable**, not story-specific details.
+
+## Update CLAUDE.md Files
+
+Before committing, check if any edited files have learnings worth preserving in nearby CLAUDE.md files:
+
+1. **Identify directories with edited files** - Look at which directories you modified
+2. **Check for existing CLAUDE.md** - Look for CLAUDE.md in those directories or parent directories
+3. **Add valuable learnings** - If you discovered something future developers/agents should know:
+   - API patterns or conventions specific to that module
+   - Gotchas or non-obvious requirements
+   - Dependencies between files
+   - Testing approaches for that area
+   - Configuration or environment requirements
+
+**Examples of good CLAUDE.md additions:**
+- "When modifying X, also update Y to keep them in sync"
+- "This module uses pattern Z for all API calls"
+- "Tests require the dev server running on PORT 3000"
+- "Field names must match the template exactly"
+
+**Do NOT add:**
+- Story-specific implementation details
+- Temporary debugging notes
+- Information already in progress.txt
+
+Only update CLAUDE.md if you have **genuinely reusable knowledge** that would help future work in that directory.
+
+## Quality Requirements
+
+- ALL commits must pass your project's quality checks (typecheck, lint, test)
+- Do NOT commit broken code
+- Keep changes focused and minimal
+- Follow existing code patterns
+
+## Browser Testing (If Available)
+
+For any story that changes UI, verify it works in the browser if you have browser testing tools configured (e.g., via MCP):
+
+1. Navigate to the relevant page
+2. Verify the UI changes work as expected
+3. Take a screenshot if helpful for the progress log
+
+If no browser tools are available, note in your progress report that manual browser verification is needed.
+
+## Stop Condition
+
+After completing a user story, check if ALL stories have `passes: true`.
+
+If ALL stories are complete and passing, reply with:
+<promise>COMPLETE</promise>
+
+If there are still stories with `passes: false`, end your response normally (another iteration will pick up the next story).
+
+## Important
+
+- Work on ONE story per iteration
+- Commit frequently
+- Keep CI green
+- Read the Codebase Patterns section in progress.txt before starting

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,0 +1,3 @@
+# Ralph Progress Log
+Started: Fri 27 Mar 2026 17:38:40 AEST
+---

--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Ralph Wiggum - Long-running AI agent loop
+# Usage: ./ralph.sh [--tool amp|claude] [max_iterations]
+
+set -e
+
+# Parse arguments
+TOOL="amp"  # Default to amp for backwards compatibility
+MAX_ITERATIONS=10
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --tool)
+      TOOL="$2"
+      shift 2
+      ;;
+    --tool=*)
+      TOOL="${1#*=}"
+      shift
+      ;;
+    *)
+      # Assume it's max_iterations if it's a number
+      if [[ "$1" =~ ^[0-9]+$ ]]; then
+        MAX_ITERATIONS="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+# Validate tool choice
+if [[ "$TOOL" != "amp" && "$TOOL" != "claude" ]]; then
+  echo "Error: Invalid tool '$TOOL'. Must be 'amp' or 'claude'."
+  exit 1
+fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRD_FILE="$SCRIPT_DIR/prd.json"
+PROGRESS_FILE="$SCRIPT_DIR/progress.txt"
+ARCHIVE_DIR="$SCRIPT_DIR/archive"
+LAST_BRANCH_FILE="$SCRIPT_DIR/.last-branch"
+
+# Archive previous run if branch changed
+if [ -f "$PRD_FILE" ] && [ -f "$LAST_BRANCH_FILE" ]; then
+  CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
+  LAST_BRANCH=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
+  
+  if [ -n "$CURRENT_BRANCH" ] && [ -n "$LAST_BRANCH" ] && [ "$CURRENT_BRANCH" != "$LAST_BRANCH" ]; then
+    # Archive the previous run
+    DATE=$(date +%Y-%m-%d)
+    # Strip "ralph/" prefix from branch name for folder
+    FOLDER_NAME=$(echo "$LAST_BRANCH" | sed 's|^ralph/||')
+    ARCHIVE_FOLDER="$ARCHIVE_DIR/$DATE-$FOLDER_NAME"
+    
+    echo "Archiving previous run: $LAST_BRANCH"
+    mkdir -p "$ARCHIVE_FOLDER"
+    [ -f "$PRD_FILE" ] && cp "$PRD_FILE" "$ARCHIVE_FOLDER/"
+    [ -f "$PROGRESS_FILE" ] && cp "$PROGRESS_FILE" "$ARCHIVE_FOLDER/"
+    echo "   Archived to: $ARCHIVE_FOLDER"
+    
+    # Reset progress file for new run
+    echo "# Ralph Progress Log" > "$PROGRESS_FILE"
+    echo "Started: $(date)" >> "$PROGRESS_FILE"
+    echo "---" >> "$PROGRESS_FILE"
+  fi
+fi
+
+# Track current branch
+if [ -f "$PRD_FILE" ]; then
+  CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
+  if [ -n "$CURRENT_BRANCH" ]; then
+    echo "$CURRENT_BRANCH" > "$LAST_BRANCH_FILE"
+  fi
+fi
+
+# Initialize progress file if it doesn't exist
+if [ ! -f "$PROGRESS_FILE" ]; then
+  echo "# Ralph Progress Log" > "$PROGRESS_FILE"
+  echo "Started: $(date)" >> "$PROGRESS_FILE"
+  echo "---" >> "$PROGRESS_FILE"
+fi
+
+echo "Starting Ralph - Tool: $TOOL - Max iterations: $MAX_ITERATIONS"
+
+for i in $(seq 1 $MAX_ITERATIONS); do
+  echo ""
+  echo "==============================================================="
+  echo "  Ralph Iteration $i of $MAX_ITERATIONS ($TOOL)"
+  echo "==============================================================="
+
+  # Run the selected tool with the ralph prompt
+  if [[ "$TOOL" == "amp" ]]; then
+    OUTPUT=$(cat "$SCRIPT_DIR/prompt.md" | amp --dangerously-allow-all 2>&1 | tee /dev/stderr) || true
+  else
+    # Claude Code: use --dangerously-skip-permissions for autonomous operation, --print for output
+    OUTPUT=$(wet claude --dangerously-skip-permissions --print < "$SCRIPT_DIR/CLAUDE.md" 2>&1 | tee /dev/stderr) || true
+  fi
+  
+  # Check for completion signal
+  if echo "$OUTPUT" | grep -q "<promise>COMPLETE</promise>"; then
+    echo ""
+    echo "Ralph completed all tasks!"
+    echo "Completed at iteration $i of $MAX_ITERATIONS"
+    exit 0
+  fi
+  
+  echo "Iteration $i complete. Continuing..."
+  sleep 2
+done
+
+echo ""
+echo "Ralph reached max iterations ($MAX_ITERATIONS) without completing all tasks."
+echo "Check $PROGRESS_FILE for status."
+exit 1

--- a/src/claude_code.rs
+++ b/src/claude_code.rs
@@ -107,6 +107,9 @@ struct ContentBlock {
     /// Tool use input arguments
     #[serde(default)]
     input: Option<serde_json::Value>,
+    /// Tool result: links back to the tool_use id
+    #[serde(default)]
+    tool_use_id: Option<String>,
 }
 
 /// Format a user message as stream-json input for the Claude CLI.
@@ -365,7 +368,8 @@ impl<'a> Iterator for StreamTurnIterator<'a> {
                                                             v.to_string()
                                                         }
                                                     }).unwrap_or_default();
-                                                    eprintln!("{}[verbose]{} {}tool:{} {}{}{} {}{}{}", color::DIM, color::RESET, color::DIM, color::RESET, color::TOOL, name, color::RESET, color::LIGHT, input_preview, color::RESET);
+                                                    let id_short = block.id.as_deref().unwrap_or("").chars().take(12).collect::<String>();
+                                                    eprintln!("{}[verbose]{} {}tool:{} {}{}{} {}{}{} {}({}){}", color::DIM, color::RESET, color::DIM, color::RESET, color::TOOL, name, color::RESET, color::LIGHT, input_preview, color::RESET, color::DIM, id_short, color::RESET);
                                                 }
                                             }
                                             "thinking" => {
@@ -396,7 +400,8 @@ impl<'a> Iterator for StreamTurnIterator<'a> {
                                                     })
                                                     .or_else(|| block.text.clone())
                                                     .unwrap_or_default();
-                                                eprintln!("{}[verbose]{} {}result:{}", color::DIM, color::RESET, color::DIM, color::RESET);
+                                                let id_short = block.tool_use_id.as_deref().unwrap_or("").chars().take(12).collect::<String>();
+                                                eprintln!("{}[verbose]{} {}result:{} {}({}){}", color::DIM, color::RESET, color::DIM, color::RESET, color::DIM, id_short, color::RESET);
                                                 eprintln!("{}{}{}", color::RESULT, result_text, color::RESET);
                                             }
                                         }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -391,12 +391,16 @@ pub fn execute_steps(
             source = %step.source_file.display(),
             "step execution begin"
         );
+        let display_source = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| step.source_file.strip_prefix(&cwd).ok().map(|p| p.display().to_string()))
+            .unwrap_or_else(|| step.source_file.display().to_string());
         println!(
             "STEP {}/{} ... {} (from {})",
             step.step_id + 1,
             total_steps,
             instruction_summary,
-            step.source_file.display()
+            display_source
         );
 
         let step_start = Instant::now();
@@ -516,13 +520,7 @@ pub fn execute_steps(
         }
     }
 
-    let all_passed = outcomes.iter().all(|o| o.result.is_pass());
-    let total_duration = run_start.elapsed();
-
-    // Print final run status
-    print_run_summary(&outcomes, total_duration, total_steps);
-
-    // Send teardown message (best-effort, non-fatal)
+    // Send teardown message before summary (best-effort, non-fatal)
     if !interrupted.load(Ordering::Relaxed) {
         println!("TEARDOWN .. cleaning up");
         let teardown_msg = StepMessage {
@@ -565,6 +563,12 @@ pub fn execute_steps(
             }
         }
     }
+
+    let all_passed = outcomes.iter().all(|o| o.result.is_pass());
+    let total_duration = run_start.elapsed();
+
+    // Print final run status (after teardown)
+    print_run_summary(&outcomes, total_duration, total_steps);
 
     // Flush/close the full transcript file
     drop(full_transcript_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,14 @@ use bugatti::test_file;
 /// Global flag set by the Ctrl+C handler.
 static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
+/// Display a path relative to the current directory, falling back to absolute.
+fn relative_display(path: &Path) -> String {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| path.strip_prefix(&cwd).ok().map(|p| p.display().to_string()))
+        .unwrap_or_else(|| path.display().to_string())
+}
+
 /// Check whether the run has been interrupted by Ctrl+C.
 pub fn is_interrupted() -> bool {
     INTERRUPTED.load(Ordering::Relaxed)
@@ -58,6 +66,9 @@ fn main() {
     }
 
     let cli = Cli::parse();
+
+    println!("\x1b[1mbugatti\x1b[0m \x1b[38;5;243mv{}\x1b[0m", env!("CARGO_PKG_VERSION"));
+    println!();
 
     let code = match cli.command {
         Commands::Test { path, skip_cmds, skip_readiness, strict_warnings, verbose } => {
@@ -256,7 +267,7 @@ impl<'a> PipelineContext<'a> {
             name: self.test_name.to_string(),
             exit_code,
             run_id: Some(self.run_id.0.clone()),
-            report_path: Some(report::report_path(self.artifact_dir).display().to_string()),
+            report_path: Some(relative_display(&report::report_path(self.artifact_dir))),
             error: Some(error),
         }
     }
@@ -311,6 +322,21 @@ fn run_test_with_artifacts(ctx: &PipelineContext, steps: Vec<bugatti::expand::Ex
         test_file = %ctx.test_path.display(),
         "starting test pipeline"
     );
+
+    // Print per-test run info
+    let dim = "\x1b[38;5;243m";
+    let light = "\x1b[38;5;250m";
+    let reset = "\x1b[0m";
+    if ctx.effective.provider.agent_args.is_empty() {
+        println!("  {dim}Provider:{reset}  {}", ctx.effective.provider.name);
+    } else {
+        println!("  {dim}Provider:{reset}  {} {light}({}){reset}", ctx.effective.provider.name, ctx.effective.provider.agent_args.join(" "));
+    }
+    println!("  {dim}Run ID:{reset}    {}", ctx.run_id);
+    println!("  {dim}Steps:{reset}     {}", steps.len());
+    println!("  {dim}Artifacts:{reset}");
+    println!("  {}", relative_display(&ctx.artifact_dir.root));
+    println!();
 
     let mut no_processes = vec![];
 
@@ -414,7 +440,7 @@ fn run_test_with_artifacts(ctx: &PipelineContext, steps: Vec<bugatti::expand::Ex
         name: ctx.test_name.to_string(),
         exit_code,
         run_id: Some(ctx.run_id.0.clone()),
-        report_path: Some(report::report_path(ctx.artifact_dir).display().to_string()),
+        report_path: Some(relative_display(&report::report_path(ctx.artifact_dir))),
         error: None,
     }
 }
@@ -452,7 +478,7 @@ fn run_discovery(project_root: &Path, skip_cmds: &[String], skip_readiness: &[St
 
     println!("Found {} root test file(s):\n", discovery.tests.len());
     for test in &discovery.tests {
-        println!("  - {} ({})", test.name, test.path.display());
+        println!("  - {} ({})", test.name, relative_display(&test.path));
     }
     println!();
 
@@ -506,7 +532,7 @@ fn run_single_test(
     verbose: bool,
 ) -> TestRunResult {
     println!("═══════════════════════════════════════════════════════");
-    println!("Running: {} ({})", test.name, test.path.display());
+    println!("Running: {} ({})", test.name, relative_display(&test.path));
     println!("═══════════════════════════════════════════════════════");
 
     let result = run_test_pipeline(project_root, &test.path, skip_cmds, skip_readiness, strict_warnings, verbose);
@@ -550,7 +576,7 @@ fn print_aggregate_summary(
         println!(
             "  {status} ........ {} ({})",
             result.name,
-            result.path.display()
+            relative_display(&result.path)
         );
         if let Some(err) = &result.error {
             println!("               {err}");


### PR DESCRIPTION
## Summary
- Show version banner on startup and per-test run info (provider, run ID, steps, artifact dir)
- Display all paths relative to CWD instead of absolute paths
- Move teardown phase before the final summary so cleanup happens before results are printed
- Show tool_use IDs in verbose output for easier debugging
- Update all example configs with consistent agent_args (haiku, medium effort, no-session-persistence) and improved extra_system_prompt wording
- Add rust-cli CLAUDE.md and ralph scripts

## Test plan
- [ ] Run `bugatti test` in each example project and verify output shows relative paths and version banner
- [ ] Confirm teardown runs before the summary is printed
- [ ] Run with `--verbose` and verify tool_use IDs appear in output