### PR TITLE
Refactor runtime to async

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Instructions
+
+## Quality Checks
+
+- Formatting checks are not sufficient validation. Rust changes must pass a strict compile check.
+- Treat Rust warnings as errors for Cargo validation commands. Use `RUSTFLAGS="-D warnings"` with `cargo check`, `cargo build`, and `cargo test`.
+- Run Clippy with warnings denied: `cargo clippy -- -D warnings`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Provider sessions, command execution, and the update checker now use Tokio async I/O. Step and teardown timeouts are enforced while waiting for each streamed chunk, and `pi`/`codex` subprocesses are killed on drop so abandoned turns don't linger.
+
 ## [0.6.0] - 2026-07-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +130,7 @@ dependencies = [
 name = "bugatti"
 version = "0.6.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "clap",
  "ctrlc",
@@ -134,6 +146,7 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
+ "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -396,7 +409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -404,18 +416,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -430,10 +430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-io",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1114,9 +1111,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1334,6 +1329,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,8 +1503,21 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "A CLI for plain-English, agent-assisted local application verification using *.test.toml files"
 
 [dependencies]
+async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
@@ -18,7 +19,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "fmt"] }
 uuid = { version = "1", features = ["v4"] }
 which = "7"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "io-util", "time", "fs"] }
 semver = "1"
 sha2 = "0.10"
 flate2 = "1"

--- a/src/claude_code.rs
+++ b/src/claude_code.rs
@@ -1,10 +1,15 @@
 use crate::config::Config;
 use crate::output;
-use crate::provider::{AgentSession, BootstrapMessage, OutputChunk, ProviderError, StepMessage};
+use crate::provider::{
+    AgentSession, BootstrapMessage, OutputChunk, OutputStream, ProviderError, StepMessage,
+    VecOutputStream,
+};
+use async_trait::async_trait;
 use serde::Deserialize;
-use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, Command, Stdio};
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
 
 /// Claude Code CLI provider adapter.
 ///
@@ -28,7 +33,7 @@ pub struct ClaudeCodeAdapter {
     /// Stdin handle for sending messages.
     stdin: Option<ChildStdin>,
     /// Buffered reader for stdout.
-    reader: Option<BufReader<std::process::ChildStdout>>,
+    reader: Option<BufReader<tokio::process::ChildStdout>>,
 }
 
 /// Format a step message with metadata prefix for sending to the provider.
@@ -147,6 +152,7 @@ impl ClaudeCodeAdapter {
         if self.verbose {
             let c = output::stderr_colors();
             let args: Vec<_> = cmd
+                .as_std()
                 .get_args()
                 .map(|a| a.to_string_lossy().to_string())
                 .collect();
@@ -163,7 +169,7 @@ impl ClaudeCodeAdapter {
             eprintln!(
                 "{}         binary: {}{}",
                 c.dim,
-                cmd.get_program().to_string_lossy(),
+                cmd.as_std().get_program().to_string_lossy(),
                 c.reset
             );
         }
@@ -189,12 +195,11 @@ impl ClaudeCodeAdapter {
         Ok(())
     }
 
-    /// Send a message to the long-lived process and return a streaming iterator.
-    fn send_message(
+    /// Send a message to the long-lived process and return a streaming output stream.
+    async fn send_message(
         &mut self,
         message: &str,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
         self.ensure_started()?;
 
         let stdin = self
@@ -220,12 +225,15 @@ impl ClaudeCodeAdapter {
 
         stdin
             .write_all(input_line.as_bytes())
+            .await
             .map_err(|e| ProviderError::SendFailed(format!("failed to write to stdin: {e}")))?;
         stdin
             .write_all(b"\n")
+            .await
             .map_err(|e| ProviderError::SendFailed(format!("failed to write newline: {e}")))?;
         stdin
             .flush()
+            .await
             .map_err(|e| ProviderError::SendFailed(format!("failed to flush stdin: {e}")))?;
 
         let reader = self
@@ -233,7 +241,7 @@ impl ClaudeCodeAdapter {
             .as_mut()
             .ok_or_else(|| ProviderError::SendFailed("stdout reader not available".to_string()))?;
 
-        Ok(Box::new(StreamTurnIterator {
+        Ok(Box::new(StreamTurnStream {
             reader,
             done: false,
             verbose: self.verbose,
@@ -246,6 +254,7 @@ impl ClaudeCodeAdapter {
     }
 }
 
+#[async_trait]
 impl AgentSession for ClaudeCodeAdapter {
     fn initialize(
         config: &Config,
@@ -274,37 +283,35 @@ impl AgentSession for ClaudeCodeAdapter {
         })
     }
 
-    fn start(&mut self) -> Result<(), ProviderError> {
+    async fn start(&mut self) -> Result<(), ProviderError> {
         // Process is spawned lazily on first send_step, after bootstrap content is available.
         tracing::info!("claude-code session ready (process will launch on first message)");
         Ok(())
     }
 
-    fn send_bootstrap(
+    async fn send_bootstrap(
         &mut self,
         message: BootstrapMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
         // Store bootstrap content — it will be passed as --append-system-prompt at launch.
         // If the process is already running, send as a regular message (shouldn't happen in normal flow).
         if self.child.is_some() {
-            return self.send_message(&message.content);
+            return self.send_message(&message.content).await;
         }
         self.bootstrap_content = Some(message.content);
-        // Return an empty iterator since no API call is made
-        Ok(Box::new(std::iter::once(Ok(OutputChunk::Done))))
+        // Return a single Done chunk since no API call is made
+        Ok(Box::new(VecOutputStream::done()))
     }
 
-    fn send_step(
+    async fn send_step(
         &mut self,
         message: StepMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
         let formatted = format_step_message(&message);
-        self.send_message(&formatted)
+        self.send_message(&formatted).await
     }
 
-    fn close(&mut self) -> Result<(), ProviderError> {
+    async fn close(&mut self) -> Result<(), ProviderError> {
         tracing::info!("closing claude-code session");
 
         // Drop stdin to signal EOF — the process will exit
@@ -312,7 +319,7 @@ impl AgentSession for ClaudeCodeAdapter {
         self.reader.take();
 
         if let Some(mut child) = self.child.take() {
-            match child.wait() {
+            match child.wait().await {
                 Ok(status) => {
                     tracing::info!(exit_status = %status, "claude process exited");
                 }
@@ -326,22 +333,21 @@ impl AgentSession for ClaudeCodeAdapter {
     }
 }
 
-/// Iterator that reads one turn of streamed output from the long-lived process.
+/// Stream that reads one turn of streamed output from the long-lived process.
 ///
 /// Reads JSONL from stdout, parsing each line into `OutputChunk` values.
 /// Yields `OutputChunk::Done` when a `result` event is received (turn complete).
 /// The process stays alive for the next message.
-struct StreamTurnIterator<'a> {
-    reader: &'a mut BufReader<std::process::ChildStdout>,
+struct StreamTurnStream<'a> {
+    reader: &'a mut BufReader<tokio::process::ChildStdout>,
     done: bool,
     verbose: bool,
     colors: Option<&'static output::Colors>,
 }
 
-impl<'a> Iterator for StreamTurnIterator<'a> {
-    type Item = Result<OutputChunk, ProviderError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
+#[async_trait]
+impl<'a> OutputStream for StreamTurnStream<'a> {
+    async fn next_chunk(&mut self) -> Option<Result<OutputChunk, ProviderError>> {
         if self.done {
             return None;
         }
@@ -350,7 +356,7 @@ impl<'a> Iterator for StreamTurnIterator<'a> {
 
         loop {
             let mut line = String::new();
-            match self.reader.read_line(&mut line) {
+            match self.reader.read_line(&mut line).await {
                 Ok(0) => {
                     // EOF — process exited unexpectedly
                     self.done = true;
@@ -541,8 +547,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn send_message_fails_with_bad_binary() {
+    #[tokio::test]
+    async fn send_message_fails_with_bad_binary() {
         let mut adapter = ClaudeCodeAdapter {
             binary_path: PathBuf::from("/nonexistent/claude"),
             agent_args: vec![],
@@ -554,12 +560,12 @@ mod tests {
             bootstrap_content: None,
         };
 
-        let result = adapter.send_message("hello");
+        let result = adapter.send_message("hello").await;
         assert!(result.is_err(), "expected error with nonexistent binary");
     }
 
-    #[test]
-    fn close_cleans_up_handles() {
+    #[tokio::test]
+    async fn close_cleans_up_handles() {
         let mut adapter = ClaudeCodeAdapter {
             binary_path: PathBuf::from("/usr/bin/claude"),
             agent_args: vec![],
@@ -572,7 +578,7 @@ mod tests {
         };
 
         // Close with no process should succeed
-        adapter.close().unwrap();
+        adapter.close().await.unwrap();
         assert!(adapter.child.is_none());
         assert!(adapter.stdin.is_none());
         assert!(adapter.reader.is_none());
@@ -621,8 +627,8 @@ mod tests {
         assert_eq!(parsed["message"]["content"], "line1\nline2");
     }
 
-    #[test]
-    fn stream_turn_iterator_with_mock_process() {
+    #[tokio::test]
+    async fn stream_turn_stream_with_mock_process() {
         // Simulate stdout with assistant + result events
         let mut child = Command::new("sh")
             .arg("-c")
@@ -637,17 +643,17 @@ mod tests {
 
         // Skip system init
         let mut init_line = String::new();
-        reader.read_line(&mut init_line).unwrap();
+        reader.read_line(&mut init_line).await.unwrap();
 
-        let mut iter = StreamTurnIterator {
-            reader: unsafe { &mut *(&mut reader as *mut BufReader<std::process::ChildStdout>) },
+        let mut stream = StreamTurnStream {
+            reader: &mut reader,
             done: false,
             verbose: false,
             colors: None,
         };
 
         let mut collected = Vec::new();
-        for item in &mut iter {
+        while let Some(item) = stream.next_chunk().await {
             match item {
                 Ok(OutputChunk::Text(text)) => collected.push(text),
                 Ok(OutputChunk::Done) => break,
@@ -656,11 +662,11 @@ mod tests {
         }
 
         assert_eq!(collected, vec!["Hello"]);
-        let _ = child.wait();
+        let _ = child.wait().await;
     }
 
-    #[test]
-    fn stream_turn_iterator_reports_error_events() {
+    #[tokio::test]
+    async fn stream_turn_stream_reports_error_events() {
         let mut child = Command::new("sh")
             .arg("-c")
             .arg(r#"echo '{"type":"error","error":"something went wrong"}'"#)
@@ -672,25 +678,25 @@ mod tests {
         let stdout = child.stdout.take().unwrap();
         let mut reader = BufReader::new(stdout);
 
-        let mut iter = StreamTurnIterator {
-            reader: unsafe { &mut *(&mut reader as *mut BufReader<std::process::ChildStdout>) },
+        let mut stream = StreamTurnStream {
+            reader: &mut reader,
             done: false,
             verbose: false,
             colors: None,
         };
 
-        let result = iter.next();
+        let result = stream.next_chunk().await;
         assert!(result.is_some());
         let item = result.unwrap();
         assert!(
             matches!(item, Err(ProviderError::StreamError(ref msg)) if msg == "something went wrong"),
             "expected StreamError, got: {item:?}"
         );
-        let _ = child.wait();
+        let _ = child.wait().await;
     }
 
-    #[test]
-    fn stream_turn_iterator_skips_non_json_lines() {
+    #[tokio::test]
+    async fn stream_turn_stream_skips_non_json_lines() {
         let mut child = Command::new("sh")
             .arg("-c")
             .arg(r#"echo 'not json'; echo '{"type":"assistant","message":{"content":[{"type":"text","text":"text"}]}}'; echo '{"type":"result","result":"text","subtype":"success"}';"#)
@@ -702,15 +708,15 @@ mod tests {
         let stdout = child.stdout.take().unwrap();
         let mut reader = BufReader::new(stdout);
 
-        let mut iter = StreamTurnIterator {
-            reader: unsafe { &mut *(&mut reader as *mut BufReader<std::process::ChildStdout>) },
+        let mut stream = StreamTurnStream {
+            reader: &mut reader,
             done: false,
             verbose: false,
             colors: None,
         };
 
         let mut texts = Vec::new();
-        for item in &mut iter {
+        while let Some(item) = stream.next_chunk().await {
             match item {
                 Ok(OutputChunk::Text(t)) => texts.push(t),
                 Ok(OutputChunk::Done) => break,
@@ -719,7 +725,7 @@ mod tests {
         }
 
         assert_eq!(texts, vec!["text"]);
-        let _ = child.wait();
+        let _ = child.wait().await;
     }
 
     #[test]

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -1,11 +1,14 @@
 use crate::config::Config;
 use crate::provider::{
-    format_step_message, AgentSession, BootstrapMessage, OutputChunk, ProviderError, StepMessage,
+    format_step_message, AgentSession, BootstrapMessage, OutputChunk, OutputStream, ProviderError,
+    StepMessage,
 };
+use async_trait::async_trait;
 use serde::Deserialize;
-use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdout, Command, Stdio};
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdout, Command};
 
 /// OpenAI Codex CLI provider adapter.
 ///
@@ -45,15 +48,15 @@ impl CodexAdapter {
         path
     }
 
-    fn spawn_turn(
+    async fn spawn_turn(
         &mut self,
         prompt: &str,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
         let output_path = self.next_output_path();
         let requires_thread_id = self.thread_id.is_none();
 
         let mut cmd = Command::new(&self.binary_path);
+        cmd.kill_on_drop(true);
         cmd.arg("exec");
         if let Some(thread_id) = self.thread_id.as_deref() {
             cmd.arg("resume").arg(thread_id);
@@ -76,12 +79,13 @@ impl CodexAdapter {
 
         if self.verbose {
             let args: Vec<_> = cmd
+                .as_std()
                 .get_args()
                 .map(|arg| arg.to_string_lossy().to_string())
                 .collect();
             eprintln!(
                 "\x1b[38;5;243m[verbose]\x1b[0m \x1b[38;5;243mlaunch:\x1b[0m \x1b[38;5;152m{} {}\x1b[0m",
-                cmd.get_program().to_string_lossy(),
+                cmd.as_std().get_program().to_string_lossy(),
                 args.join(" ")
             );
         }
@@ -96,9 +100,11 @@ impl CodexAdapter {
             .ok_or_else(|| ProviderError::StartFailed("failed to capture stdin".to_string()))?;
         stdin
             .write_all(prompt.as_bytes())
+            .await
             .map_err(|e| ProviderError::SendFailed(format!("failed to write to stdin: {e}")))?;
         stdin
             .flush()
+            .await
             .map_err(|e| ProviderError::SendFailed(format!("failed to flush stdin: {e}")))?;
         drop(stdin);
 
@@ -107,7 +113,7 @@ impl CodexAdapter {
             .take()
             .ok_or_else(|| ProviderError::StartFailed("failed to capture stdout".to_string()))?;
 
-        Ok(Box::new(CodexTurnIterator {
+        Ok(Box::new(CodexTurnStream {
             child,
             reader: BufReader::new(stdout),
             output_path,
@@ -121,6 +127,7 @@ impl CodexAdapter {
     }
 }
 
+#[async_trait]
 impl AgentSession for CodexAdapter {
     fn initialize(
         config: &Config,
@@ -141,32 +148,30 @@ impl AgentSession for CodexAdapter {
         })
     }
 
-    fn start(&mut self) -> Result<(), ProviderError> {
+    async fn start(&mut self) -> Result<(), ProviderError> {
         Ok(())
     }
 
-    fn send_bootstrap(
+    async fn send_bootstrap(
         &mut self,
         message: BootstrapMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
-        self.spawn_turn(&message.content)
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
+        self.spawn_turn(&message.content).await
     }
 
-    fn send_step(
+    async fn send_step(
         &mut self,
         message: StepMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
-        self.spawn_turn(&format_step_message(&message))
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
+        self.spawn_turn(&format_step_message(&message)).await
     }
 
-    fn close(&mut self) -> Result<(), ProviderError> {
+    async fn close(&mut self) -> Result<(), ProviderError> {
         Ok(())
     }
 }
 
-struct CodexTurnIterator<'a> {
+struct CodexTurnStream<'a> {
     child: Child,
     reader: BufReader<ChildStdout>,
     output_path: PathBuf,
@@ -178,10 +183,9 @@ struct CodexTurnIterator<'a> {
     requires_thread_id: bool,
 }
 
-impl<'a> Iterator for CodexTurnIterator<'a> {
-    type Item = Result<OutputChunk, ProviderError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
+#[async_trait]
+impl<'a> OutputStream for CodexTurnStream<'a> {
+    async fn next_chunk(&mut self) -> Option<Result<OutputChunk, ProviderError>> {
         if let Some(output) = self.pending_output.take() {
             self.pending_done = true;
             return Some(Ok(OutputChunk::Text(output)));
@@ -199,9 +203,9 @@ impl<'a> Iterator for CodexTurnIterator<'a> {
 
         loop {
             let mut line = String::new();
-            match self.reader.read_line(&mut line) {
+            match self.reader.read_line(&mut line).await {
                 Ok(0) => {
-                    let status = match self.child.wait() {
+                    let status = match self.child.wait().await {
                         Ok(status) => status,
                         Err(e) => {
                             self.complete = true;
@@ -226,7 +230,7 @@ impl<'a> Iterator for CodexTurnIterator<'a> {
                         return Some(Err(ProviderError::StreamError(message)));
                     }
 
-                    let output = match std::fs::read_to_string(&self.output_path) {
+                    let output = match tokio::fs::read_to_string(&self.output_path).await {
                         Ok(contents) => contents,
                         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
                         Err(e) => {
@@ -243,8 +247,8 @@ impl<'a> Iterator for CodexTurnIterator<'a> {
                         return Some(Ok(OutputChunk::Done));
                     }
 
-                    self.pending_output = Some(output);
-                    return self.next();
+                    self.pending_done = true;
+                    return Some(Ok(OutputChunk::Text(output)));
                 }
                 Ok(_) => {
                     let trimmed = line.trim();
@@ -368,11 +372,11 @@ exit 1
         script_path
     }
 
-    fn collect_output(
-        stream: Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>,
+    async fn collect_output(
+        mut stream: Box<dyn OutputStream + '_>,
     ) -> Result<String, ProviderError> {
         let mut output = String::new();
-        for item in stream {
+        while let Some(item) = stream.next_chunk().await {
             match item? {
                 OutputChunk::Text(text) => output.push_str(&text),
                 OutputChunk::Done => break,
@@ -381,8 +385,8 @@ exit 1
         Ok(output)
     }
 
-    #[test]
-    fn send_bootstrap_starts_new_codex_thread() {
+    #[tokio::test]
+    async fn send_bootstrap_starts_new_codex_thread() {
         let tmp = tempfile::tempdir().unwrap();
         let artifact_dir = tmp.path().join("artifacts");
         fs::create_dir_all(&artifact_dir).unwrap();
@@ -403,16 +407,18 @@ exit 1
                     session_id: SessionId("sess-123".to_string()),
                     content: "Bootstrap prompt".to_string(),
                 })
+                .await
                 .unwrap(),
         )
+        .await
         .unwrap();
 
         assert_eq!(adapter.thread_id.as_deref(), Some("thread-123"));
         assert_eq!(output, "Bootstrap acknowledged.\n");
     }
 
-    #[test]
-    fn send_step_resumes_existing_codex_thread() {
+    #[tokio::test]
+    async fn send_step_resumes_existing_codex_thread() {
         let tmp = tempfile::tempdir().unwrap();
         let artifact_dir = tmp.path().join("artifacts");
         fs::create_dir_all(&artifact_dir).unwrap();
@@ -436,8 +442,10 @@ exit 1
                     source_file: "tests/flow.test.toml".to_string(),
                     instruction: "Verify the login form works".to_string(),
                 })
+                .await
                 .unwrap(),
         )
+        .await
         .unwrap();
 
         assert_eq!(output, "RESULT OK\n");

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,8 +1,9 @@
 use crate::config::{CommandDef, CommandKind, Config};
 use crate::run::ArtifactDir;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::Stdio;
 use std::time::{Duration, Instant};
+use tokio::process::{Child, Command};
 
 /// Result of executing a short-lived command.
 #[derive(Debug)]
@@ -131,7 +132,7 @@ pub fn validate_skip_readiness(
 /// If any command exits non-zero, execution stops and an error is returned.
 ///
 /// Returns a list of successful command results.
-pub fn run_short_lived_commands(
+pub async fn run_short_lived_commands(
     config: &Config,
     artifact_dir: &ArtifactDir,
     skip_cmds: &[String],
@@ -147,7 +148,7 @@ pub fn run_short_lived_commands(
             continue;
         }
 
-        let result = execute_short_lived(name, def, &artifact_dir.logs)?;
+        let result = execute_short_lived(name, def, &artifact_dir.logs).await?;
         println!(
             "OK ......... {name} (exit {})",
             result.exit_code.unwrap_or(-1)
@@ -159,7 +160,7 @@ pub fn run_short_lived_commands(
 }
 
 /// Execute a single short-lived command, capturing stdout and stderr to log files.
-fn execute_short_lived(
+async fn execute_short_lived(
     name: &str,
     def: &CommandDef,
     logs_dir: &Path,
@@ -171,6 +172,7 @@ fn execute_short_lived(
         .arg("-c")
         .arg(&def.cmd)
         .output()
+        .await
         .map_err(|e| CommandError::SpawnFailed {
             name: name.to_string(),
             cmd: def.cmd.clone(),
@@ -245,7 +247,7 @@ pub fn checkpoint_path(project_root: &Path, checkpoint_id: &str) -> PathBuf {
 const DEFAULT_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Run a checkpoint save or restore command with BUGATTI_CHECKPOINT_ID and BUGATTI_CHECKPOINT_PATH.
-pub fn run_checkpoint_command(
+pub async fn run_checkpoint_command(
     cmd: &str,
     checkpoint_id: &str,
     project_root: &Path,
@@ -263,56 +265,32 @@ pub fn run_checkpoint_command(
         .map(Duration::from_secs)
         .unwrap_or(DEFAULT_CHECKPOINT_TIMEOUT);
 
-    let mut child = Command::new("sh")
+    let child = Command::new("sh")
         .arg("-c")
         .arg(cmd)
         .env("BUGATTI_CHECKPOINT_ID", checkpoint_id)
         .env("BUGATTI_CHECKPOINT_PATH", cp_path.display().to_string())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        // Ensure the process is killed if we abandon it on timeout.
+        .kill_on_drop(true)
         .spawn()
         .map_err(|e| format!("failed to spawn checkpoint command: {e}"))?;
 
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let stdout = child
-                    .stdout
-                    .take()
-                    .map(|mut s| {
-                        let mut buf = Vec::new();
-                        std::io::Read::read_to_end(&mut s, &mut buf).ok();
-                        buf
-                    })
-                    .unwrap_or_default();
-                let stderr = child
-                    .stderr
-                    .take()
-                    .map(|mut s| {
-                        let mut buf = Vec::new();
-                        std::io::Read::read_to_end(&mut s, &mut buf).ok();
-                        buf
-                    })
-                    .unwrap_or_default();
-
-                if !status.success() {
-                    print_output_tail("stderr", &stderr);
-                    print_output_tail("stdout", &stdout);
-                    return Err(format!("exited with code {}", status.code().unwrap_or(-1)));
-                }
-                return Ok(());
+    match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => {
+            if !output.status.success() {
+                print_output_tail("stderr", &output.stderr);
+                print_output_tail("stdout", &output.stdout);
+                return Err(format!(
+                    "exited with code {}",
+                    output.status.code().unwrap_or(-1)
+                ));
             }
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(format!("timed out after {}s", timeout.as_secs()));
-                }
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            Err(e) => return Err(format!("failed to wait for checkpoint command: {e}")),
+            Ok(())
         }
+        Ok(Err(e)) => Err(format!("failed to wait for checkpoint command: {e}")),
+        Err(_) => Err(format!("timed out after {}s", timeout.as_secs())),
     }
 }
 
@@ -355,7 +333,7 @@ pub struct TeardownResult {
 ///
 /// After spawning, if a readiness_url is configured, polls it until ready or timeout.
 /// Returns a list of tracked processes that must be torn down later.
-pub fn spawn_long_lived_commands(
+pub async fn spawn_long_lived_commands(
     config: &Config,
     artifact_dir: &ArtifactDir,
     skip_cmds: &[String],
@@ -378,9 +356,9 @@ pub fn spawn_long_lived_commands(
                     let timeout = readiness_timeout(def);
                     for url in &urls {
                         println!("WAIT ....... {name} (skipped): polling {url}");
-                        if let Err(e) = poll_readiness(url, timeout) {
+                        if let Err(e) = poll_readiness(url, timeout).await {
                             println!("FAIL ....... {name} (skipped): readiness check failed");
-                            teardown_processes(&mut tracked);
+                            teardown_processes(&mut tracked).await;
                             return Err(CommandError::ReadinessFailed {
                                 name: name.to_string(),
                                 url: url.to_string(),
@@ -438,10 +416,10 @@ pub fn spawn_long_lived_commands(
             let timeout = readiness_timeout(def);
             for url in &urls {
                 println!("WAIT ....... {name}: polling {url}");
-                if let Err(e) = poll_readiness(url, timeout) {
+                if let Err(e) = poll_readiness(url, timeout).await {
                     // Readiness failed - tear down what we've started
                     println!("FAIL ....... {name}: readiness check failed");
-                    teardown_processes(&mut tracked);
+                    teardown_processes(&mut tracked).await;
                     return Err(CommandError::ReadinessFailed {
                         name: name.to_string(),
                         url: url.to_string(),
@@ -464,7 +442,7 @@ fn readiness_timeout(def: &CommandDef) -> Duration {
 }
 
 /// Poll a readiness URL until it responds with a success status or timeout.
-fn poll_readiness(url: &str, timeout: Duration) -> Result<(), String> {
+async fn poll_readiness(url: &str, timeout: Duration) -> Result<(), String> {
     tracing::info!(
         url = url,
         timeout_secs = timeout.as_secs(),
@@ -474,7 +452,7 @@ fn poll_readiness(url: &str, timeout: Duration) -> Result<(), String> {
 
     while start.elapsed() < timeout {
         // Try a simple TCP connection check by parsing the URL and connecting
-        if check_url(url) {
+        if check_url(url).await {
             tracing::info!(
                 url = url,
                 elapsed_ms = start.elapsed().as_millis() as u64,
@@ -482,7 +460,7 @@ fn poll_readiness(url: &str, timeout: Duration) -> Result<(), String> {
             );
             return Ok(());
         }
-        std::thread::sleep(READINESS_POLL_INTERVAL);
+        tokio::time::sleep(READINESS_POLL_INTERVAL).await;
     }
 
     tracing::error!(
@@ -497,12 +475,13 @@ fn poll_readiness(url: &str, timeout: Duration) -> Result<(), String> {
 }
 
 /// Check if a URL is reachable by attempting a simple HTTP GET via a spawned curl process.
-fn check_url(url: &str) -> bool {
+async fn check_url(url: &str) -> bool {
     Command::new("curl")
         .args(["-sf", "--max-time", "2", "-o", "/dev/null", url])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
+        .await
         .map(|s| s.success())
         .unwrap_or(false)
 }
@@ -522,12 +501,12 @@ pub fn check_for_unexpected_exits(
 
 /// Tear down all tracked long-lived processes by sending SIGTERM.
 /// Returns results describing the outcome for each process.
-pub fn teardown_processes(processes: &mut [TrackedProcess]) -> Vec<TeardownResult> {
+pub async fn teardown_processes(processes: &mut [TrackedProcess]) -> Vec<TeardownResult> {
     tracing::info!(count = processes.len(), "tearing down long-lived processes");
     let mut results = Vec::new();
 
     for process in processes.iter_mut() {
-        let result = teardown_single(process);
+        let result = teardown_single(process).await;
         tracing::info!(
             command = result.name.as_str(),
             success = result.success,
@@ -541,7 +520,7 @@ pub fn teardown_processes(processes: &mut [TrackedProcess]) -> Vec<TeardownResul
 }
 
 /// Tear down a single process with SIGTERM, waiting briefly for exit.
-fn teardown_single(process: &mut TrackedProcess) -> TeardownResult {
+async fn teardown_single(process: &mut TrackedProcess) -> TeardownResult {
     let name = process.name.clone();
 
     // Check if already exited
@@ -566,45 +545,37 @@ fn teardown_single(process: &mut TrackedProcess) -> TeardownResult {
     // Send SIGTERM
     #[cfg(unix)]
     {
-        unsafe {
-            libc::kill(process.child.id() as libc::pid_t, libc::SIGTERM);
+        if let Some(pid) = process.child.id() {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
         }
     }
     #[cfg(not(unix))]
     {
-        let _ = process.child.kill();
+        let _ = process.child.start_kill();
     }
 
     // Wait briefly for orderly shutdown
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        match process.child.try_wait() {
-            Ok(Some(status)) => {
-                return TeardownResult {
-                    name,
-                    success: true,
-                    message: format!("terminated with code {}", status.code().unwrap_or(-1)),
-                };
-            }
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    // Force kill after timeout
-                    let _ = process.child.kill();
-                    let _ = process.child.wait();
-                    return TeardownResult {
-                        name,
-                        success: false,
-                        message: "did not exit after SIGTERM; force killed".to_string(),
-                    };
-                }
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            Err(e) => {
-                return TeardownResult {
-                    name,
-                    success: false,
-                    message: format!("error waiting for process: {e}"),
-                };
+    match tokio::time::timeout(Duration::from_secs(5), process.child.wait()).await {
+        Ok(Ok(status)) => TeardownResult {
+            name,
+            success: true,
+            message: format!("terminated with code {}", status.code().unwrap_or(-1)),
+        },
+        Ok(Err(e)) => TeardownResult {
+            name,
+            success: false,
+            message: format!("error waiting for process: {e}"),
+        },
+        Err(_) => {
+            // Force kill after timeout
+            let _ = process.child.start_kill();
+            let _ = process.child.wait().await;
+            TeardownResult {
+                name,
+                success: false,
+                message: "did not exit after SIGTERM; force killed".to_string(),
             }
         }
     }
@@ -649,8 +620,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn successful_short_lived_command() {
+    #[tokio::test]
+    async fn successful_short_lived_command() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -658,7 +629,9 @@ mod tests {
 
         let config = make_config(vec![("echo_test", CommandKind::ShortLived, "echo hello")]);
 
-        let results = run_short_lived_commands(&config, &artifact_dir, &[]).unwrap();
+        let results = run_short_lived_commands(&config, &artifact_dir, &[])
+            .await
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "echo_test");
         assert_eq!(results[0].exit_code, Some(0));
@@ -671,8 +644,8 @@ mod tests {
         assert!(std::path::Path::new(&results[0].stderr_path).exists());
     }
 
-    #[test]
-    fn failed_short_lived_command() {
+    #[tokio::test]
+    async fn failed_short_lived_command() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -680,7 +653,9 @@ mod tests {
 
         let config = make_config(vec![("fail_cmd", CommandKind::ShortLived, "exit 42")]);
 
-        let err = run_short_lived_commands(&config, &artifact_dir, &[]).unwrap_err();
+        let err = run_short_lived_commands(&config, &artifact_dir, &[])
+            .await
+            .unwrap_err();
         match err {
             CommandError::NonZeroExit {
                 name, exit_code, ..
@@ -692,8 +667,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn output_capture_to_log_files() {
+    #[tokio::test]
+    async fn output_capture_to_log_files() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -705,7 +680,9 @@ mod tests {
             "echo stdout_msg && echo stderr_msg >&2",
         )]);
 
-        let results = run_short_lived_commands(&config, &artifact_dir, &[]).unwrap();
+        let results = run_short_lived_commands(&config, &artifact_dir, &[])
+            .await
+            .unwrap();
         assert_eq!(results.len(), 1);
 
         let stdout = std::fs::read_to_string(&results[0].stdout_path).unwrap();
@@ -715,8 +692,8 @@ mod tests {
         assert!(stderr.contains("stderr_msg"));
     }
 
-    #[test]
-    fn long_lived_commands_are_skipped() {
+    #[tokio::test]
+    async fn long_lived_commands_are_skipped() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -727,14 +704,16 @@ mod tests {
             ("server", CommandKind::LongLived, "echo server"),
         ]);
 
-        let results = run_short_lived_commands(&config, &artifact_dir, &[]).unwrap();
+        let results = run_short_lived_commands(&config, &artifact_dir, &[])
+            .await
+            .unwrap();
         // Only the short-lived command should have run
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "setup");
     }
 
-    #[test]
-    fn skip_cmd_flag_excludes_command() {
+    #[tokio::test]
+    async fn skip_cmd_flag_excludes_command() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -745,14 +724,15 @@ mod tests {
             ("seed", CommandKind::ShortLived, "echo seed"),
         ]);
 
-        let results =
-            run_short_lived_commands(&config, &artifact_dir, &["migrate".to_string()]).unwrap();
+        let results = run_short_lived_commands(&config, &artifact_dir, &["migrate".to_string()])
+            .await
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "seed");
     }
 
-    #[test]
-    fn failed_command_stops_execution() {
+    #[tokio::test]
+    async fn failed_command_stops_execution() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -764,7 +744,9 @@ mod tests {
             ("b_second", CommandKind::ShortLived, "echo should_not_run"),
         ]);
 
-        let err = run_short_lived_commands(&config, &artifact_dir, &[]).unwrap_err();
+        let err = run_short_lived_commands(&config, &artifact_dir, &[])
+            .await
+            .unwrap_err();
         match err {
             CommandError::NonZeroExit { name, .. } => {
                 assert_eq!(name, "a_first");
@@ -779,8 +761,8 @@ mod tests {
 
     // --- Long-lived command tests ---
 
-    #[test]
-    fn spawn_long_lived_captures_output() {
+    #[tokio::test]
+    async fn spawn_long_lived_captures_output() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -793,12 +775,14 @@ mod tests {
             "echo long_lived_output && sleep 60",
         )]);
 
-        let mut tracked = spawn_long_lived_commands(&config, &artifact_dir, &[], &[]).unwrap();
+        let mut tracked = spawn_long_lived_commands(&config, &artifact_dir, &[], &[])
+            .await
+            .unwrap();
         assert_eq!(tracked.len(), 1);
         assert_eq!(tracked[0].name, "worker");
 
         // Give it a moment to write output
-        std::thread::sleep(Duration::from_millis(200));
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
         // Verify log files exist
         assert!(std::path::Path::new(&tracked[0].stdout_path).exists());
@@ -809,11 +793,11 @@ mod tests {
         assert!(stdout.contains("long_lived_output"), "stdout: {stdout}");
 
         // Clean up
-        teardown_processes(&mut tracked);
+        teardown_processes(&mut tracked).await;
     }
 
-    #[test]
-    fn spawn_long_lived_skip() {
+    #[tokio::test]
+    async fn spawn_long_lived_skip() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -826,15 +810,16 @@ mod tests {
 
         let mut tracked =
             spawn_long_lived_commands(&config, &artifact_dir, &["server".to_string()], &[])
+                .await
                 .unwrap();
         assert_eq!(tracked.len(), 1);
         assert_eq!(tracked[0].name, "worker");
 
-        teardown_processes(&mut tracked);
+        teardown_processes(&mut tracked).await;
     }
 
-    #[test]
-    fn teardown_stops_running_processes() {
+    #[tokio::test]
+    async fn teardown_stops_running_processes() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -842,10 +827,12 @@ mod tests {
 
         let config = make_config(vec![("sleeper", CommandKind::LongLived, "sleep 600")]);
 
-        let mut tracked = spawn_long_lived_commands(&config, &artifact_dir, &[], &[]).unwrap();
+        let mut tracked = spawn_long_lived_commands(&config, &artifact_dir, &[], &[])
+            .await
+            .unwrap();
         assert_eq!(tracked.len(), 1);
 
-        let results = teardown_processes(&mut tracked);
+        let results = teardown_processes(&mut tracked).await;
         assert_eq!(results.len(), 1);
         assert!(
             results[0].success,
@@ -854,8 +841,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn detect_unexpected_exit() {
+    #[tokio::test]
+    async fn detect_unexpected_exit() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -864,10 +851,12 @@ mod tests {
         // Command that exits immediately
         let config = make_config(vec![("quick_exit", CommandKind::LongLived, "exit 1")]);
 
-        let mut tracked = spawn_long_lived_commands(&config, &artifact_dir, &[], &[]).unwrap();
+        let mut tracked = spawn_long_lived_commands(&config, &artifact_dir, &[], &[])
+            .await
+            .unwrap();
 
         // Wait for it to exit
-        std::thread::sleep(Duration::from_millis(200));
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
         let result = check_for_unexpected_exits(&mut tracked);
         assert!(result.is_some(), "should detect unexpected exit");
@@ -944,8 +933,8 @@ mod tests {
         assert!(err.contains("not a known command"), "error: {err}");
     }
 
-    #[test]
-    fn spawn_long_lived_skip_readiness() {
+    #[tokio::test]
+    async fn spawn_long_lived_skip_readiness() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -966,14 +955,15 @@ mod tests {
             &["server".to_string()],
             &["server".to_string()],
         )
+        .await
         .unwrap();
 
         // No processes spawned (command was skipped), and no readiness error
         assert!(tracked.is_empty());
     }
 
-    #[test]
-    fn short_lived_not_spawned_as_long_lived() {
+    #[tokio::test]
+    async fn short_lived_not_spawned_as_long_lived() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -984,16 +974,18 @@ mod tests {
             ("server", CommandKind::LongLived, "sleep 60"),
         ]);
 
-        let mut tracked = spawn_long_lived_commands(&config, &artifact_dir, &[], &[]).unwrap();
+        let mut tracked = spawn_long_lived_commands(&config, &artifact_dir, &[], &[])
+            .await
+            .unwrap();
         // Only long-lived should be spawned
         assert_eq!(tracked.len(), 1);
         assert_eq!(tracked[0].name, "server");
 
-        teardown_processes(&mut tracked);
+        teardown_processes(&mut tracked).await;
     }
 
-    #[test]
-    fn commands_execute_in_declaration_order() {
+    #[tokio::test]
+    async fn commands_execute_in_declaration_order() {
         let tmp = tempfile::tempdir().unwrap();
         let run_id = RunId("test-run".to_string());
         let artifact_dir = ArtifactDir::from_run_id(tmp.path(), &run_id);
@@ -1007,7 +999,9 @@ mod tests {
             ("a_first", CommandKind::ShortLived, "echo a_first"),
         ]);
 
-        let results = run_short_lived_commands(&config, &artifact_dir, &[]).unwrap();
+        let results = run_short_lived_commands(&config, &artifact_dir, &[])
+            .await
+            .unwrap();
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].name, "z_last");
         assert_eq!(results[1].name, "a_first");

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -319,14 +319,14 @@ pub fn build_bootstrap_content(
 /// Returns the run outcome with all step results.
 /// The provider session must already be initialized and started.
 #[allow(clippy::too_many_arguments)]
-pub fn execute_steps(
+pub async fn execute_steps(
     session: &mut dyn AgentSession,
     steps: &[ExpandedStep],
     run_id: &RunId,
     session_id: &SessionId,
     artifact_dir: &ArtifactDir,
     step_timeout: Option<Duration>,
-    bootstrap_config: Option<&BootstrapConfig>,
+    bootstrap_config: Option<&BootstrapConfig<'_>>,
     checkpoint_config: Option<&crate::config::CheckpointConfig>,
     project_root: &std::path::Path,
     interrupted: &AtomicBool,
@@ -367,10 +367,10 @@ pub fn execute_steps(
         };
 
         let bootstrap_start = Instant::now();
-        match session.send_bootstrap(bootstrap_msg) {
-            Ok(stream) => {
+        match session.send_bootstrap(bootstrap_msg).await {
+            Ok(mut stream) => {
                 let mut bootstrap_transcript = String::new();
-                for chunk in stream {
+                while let Some(chunk) = stream.next_chunk().await {
                     match chunk {
                         Ok(OutputChunk::Text(text)) => bootstrap_transcript.push_str(&text),
                         Ok(OutputChunk::Done) => break,
@@ -380,6 +380,7 @@ pub fn execute_steps(
                         }
                     }
                 }
+                drop(stream);
                 // Write bootstrap transcript
                 let bootstrap_path = artifact_dir.transcripts.join("bootstrap.txt");
                 if let Err(e) = std::fs::write(&bootstrap_path, &bootstrap_transcript) {
@@ -437,7 +438,9 @@ pub fn execute_steps(
                         cp_id,
                         project_root,
                         cp_config.timeout_secs,
-                    ) {
+                    )
+                    .await
+                    {
                         println!("FAIL ....... checkpoint restore: {e}");
                         return Err(ExecutorError::CheckpointFailed(format!(
                             "restore \"{cp_id}\" failed: {e}"
@@ -524,7 +527,7 @@ pub fn execute_steps(
             .map(Duration::from_secs)
             .unwrap_or(timeout);
 
-        let result = execute_single_step(session, message, &effective_timeout, interrupted);
+        let result = execute_single_step(session, message, &effective_timeout, interrupted).await;
 
         let duration = step_start.elapsed();
 
@@ -639,7 +642,9 @@ pub fn execute_steps(
                     cp_id,
                     project_root,
                     cp_config.timeout_secs,
-                ) {
+                )
+                .await
+                {
                     println!("FAIL ....... checkpoint save: {e}");
                     return Err(ExecutorError::CheckpointFailed(format!(
                         "save \"{cp_id}\" failed: {e}"
@@ -670,16 +675,27 @@ pub fn execute_steps(
             source_file: "teardown".to_string(),
             instruction: "All test steps are complete. Close any browsers, tools, or resources you opened during this session.".to_string(),
         };
-        match session.send_step(teardown_msg) {
-            Ok(stream) => {
+        match session.send_step(teardown_msg).await {
+            Ok(mut stream) => {
                 let teardown_start = Instant::now();
                 let teardown_timeout = Duration::from_secs(30);
                 let mut teardown_transcript = String::new();
-                for chunk in stream {
-                    if teardown_start.elapsed() > teardown_timeout {
-                        tracing::warn!("teardown timed out");
-                        break;
-                    }
+                loop {
+                    let remaining = match teardown_timeout.checked_sub(teardown_start.elapsed()) {
+                        Some(r) => r,
+                        None => {
+                            tracing::warn!("teardown timed out");
+                            break;
+                        }
+                    };
+                    let chunk = match tokio::time::timeout(remaining, stream.next_chunk()).await {
+                        Ok(Some(chunk)) => chunk,
+                        Ok(None) => break,
+                        Err(_) => {
+                            tracing::warn!("teardown timed out");
+                            break;
+                        }
+                    };
                     match chunk {
                         Ok(OutputChunk::Text(text)) => teardown_transcript.push_str(&text),
                         Ok(OutputChunk::Done) => break,
@@ -689,6 +705,7 @@ pub fn execute_steps(
                         }
                     }
                 }
+                drop(stream);
                 if let Some(ref mut f) = full_transcript_file {
                     let _ = writeln!(f, "=== Teardown ===");
                     let _ = writeln!(f, "{}", teardown_transcript);
@@ -829,7 +846,11 @@ fn print_run_summary(
 ///
 /// Returns Ok((transcript, StepResult)) on successful completion,
 /// or Err((transcript, StepResult)) on failure.
-fn execute_single_step(
+///
+/// The timeout is enforced with `tokio::time::timeout` around each chunk read,
+/// so a provider that hangs mid-stream is detected as soon as the deadline passes
+/// (not only after the next chunk arrives).
+async fn execute_single_step(
     session: &mut dyn AgentSession,
     message: StepMessage,
     timeout: &Duration,
@@ -838,7 +859,7 @@ fn execute_single_step(
     let start = Instant::now();
     let mut transcript = String::new();
 
-    let stream = match session.send_step(message) {
+    let mut stream = match session.send_step(message).await {
         Ok(s) => s,
         Err(e) => {
             tracing::error!(error = %e, "provider send_step failed");
@@ -846,24 +867,42 @@ fn execute_single_step(
         }
     };
 
-    for chunk_result in stream {
-        // Check timeout
-        if start.elapsed() > *timeout {
-            tracing::error!(
-                elapsed_ms = start.elapsed().as_millis() as u64,
-                "step timed out during streaming"
-            );
-            return Err((transcript, StepResult::Timeout));
-        }
+    loop {
+        // Check timeout and compute the remaining budget for the next chunk
+        let remaining = match timeout.checked_sub(start.elapsed()) {
+            Some(r) => r,
+            None => {
+                tracing::error!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    "step timed out during streaming"
+                );
+                drop(stream);
+                return Err((transcript, StepResult::Timeout));
+            }
+        };
 
         // Check for Ctrl+C interruption
         if interrupted.load(Ordering::Relaxed) {
             tracing::warn!("step interrupted by Ctrl+C during streaming");
+            drop(stream);
             return Err((
                 transcript,
                 StepResult::ProviderFailed("interrupted by Ctrl+C".to_string()),
             ));
         }
+
+        let chunk_result = match tokio::time::timeout(remaining, stream.next_chunk()).await {
+            Ok(Some(chunk)) => chunk,
+            Ok(None) => break,
+            Err(_) => {
+                tracing::error!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    "step timed out waiting for provider output"
+                );
+                drop(stream);
+                return Err((transcript, StepResult::Timeout));
+            }
+        };
 
         match chunk_result {
             Ok(OutputChunk::Text(text)) => {
@@ -873,19 +912,12 @@ fn execute_single_step(
                 break;
             }
             Err(e) => {
+                drop(stream);
                 return Err((transcript, StepResult::ProviderFailed(e.to_string())));
             }
         }
     }
-
-    // Check timeout one more time after stream ends
-    if start.elapsed() > *timeout {
-        tracing::error!(
-            elapsed_ms = start.elapsed().as_millis() as u64,
-            "step timed out after streaming"
-        );
-        return Err((transcript, StepResult::Timeout));
-    }
+    drop(stream);
 
     // Parse result contract
     match parse_result_marker(&transcript) {
@@ -1002,6 +1034,7 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl AgentSession for MockSession {
         fn initialize(
             _config: &Config,
@@ -1014,33 +1047,33 @@ mod tests {
             Ok(Self::new(vec![]))
         }
 
-        fn start(&mut self) -> Result<(), ProviderError> {
+        async fn start(&mut self) -> Result<(), ProviderError> {
             Ok(())
         }
 
-        fn send_bootstrap(
+        async fn send_bootstrap(
             &mut self,
             _message: BootstrapMessage,
-        ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-        {
-            Ok(Box::new(std::iter::empty()))
+        ) -> Result<Box<dyn crate::provider::OutputStream + '_>, ProviderError> {
+            Ok(Box::new(crate::provider::VecOutputStream::empty()))
         }
 
-        fn send_step(
+        async fn send_step(
             &mut self,
             _message: StepMessage,
-        ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-        {
+        ) -> Result<Box<dyn crate::provider::OutputStream + '_>, ProviderError> {
             if self.call_count < self.responses.len() {
                 let idx = self.call_count;
                 self.call_count += 1;
-                Ok(Box::new(self.responses[idx].clone().into_iter()))
+                Ok(Box::new(crate::provider::VecOutputStream::new(
+                    self.responses[idx].clone(),
+                )))
             } else {
                 Err(ProviderError::SendFailed("no more responses".to_string()))
             }
         }
 
-        fn close(&mut self) -> Result<(), ProviderError> {
+        async fn close(&mut self) -> Result<(), ProviderError> {
             Ok(())
         }
     }
@@ -1087,8 +1120,8 @@ mod tests {
         (tmp, dir)
     }
 
-    #[test]
-    fn execute_steps_all_ok() {
+    #[tokio::test]
+    async fn execute_steps_all_ok() {
         let steps = test_steps();
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1120,6 +1153,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.all_passed);
@@ -1134,8 +1168,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn execute_steps_stops_on_error() {
+    #[tokio::test]
+    async fn execute_steps_stops_on_error() {
         let steps = test_steps();
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1166,6 +1200,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(!outcome.all_passed);
@@ -1176,8 +1211,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn execute_steps_warn_continues() {
+    #[tokio::test]
+    async fn execute_steps_warn_continues() {
         let steps = test_steps();
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1205,6 +1240,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.all_passed);
@@ -1215,8 +1251,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn execute_steps_missing_result_marker() {
+    #[tokio::test]
+    async fn execute_steps_missing_result_marker() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1240,6 +1276,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(!outcome.all_passed);
@@ -1249,8 +1286,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn execute_steps_provider_send_failure() {
+    #[tokio::test]
+    async fn execute_steps_provider_send_failure() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1270,6 +1307,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(!outcome.all_passed);
@@ -1279,8 +1317,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn execute_steps_provider_stream_error() {
+    #[tokio::test]
+    async fn execute_steps_provider_stream_error() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1302,6 +1340,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(!outcome.all_passed);
@@ -1313,8 +1352,8 @@ mod tests {
         assert!(outcome.steps[0].transcript.contains("partial output"));
     }
 
-    #[test]
-    fn execute_steps_writes_transcript_artifacts() {
+    #[tokio::test]
+    async fn execute_steps_writes_transcript_artifacts() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1336,6 +1375,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         // Per-step transcript
@@ -1350,8 +1390,8 @@ mod tests {
         assert!(full_transcript.is_file());
     }
 
-    #[test]
-    fn execute_steps_full_transcript_written_incrementally() {
+    #[tokio::test]
+    async fn execute_steps_full_transcript_written_incrementally() {
         let steps = test_steps();
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1383,6 +1423,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.artifact_errors.is_empty());
@@ -1397,8 +1438,8 @@ mod tests {
         assert!(contents.contains("Second step output."));
     }
 
-    #[test]
-    fn execute_steps_full_transcript_captures_partial_on_failure() {
+    #[tokio::test]
+    async fn execute_steps_full_transcript_captures_partial_on_failure() {
         let steps = test_steps();
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1429,6 +1470,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         // Full transcript should contain the first (failed) step but not the second
@@ -1440,8 +1482,8 @@ mod tests {
         assert!(outcome.artifact_errors.is_empty());
     }
 
-    #[test]
-    fn execute_steps_records_duration() {
+    #[tokio::test]
+    async fn execute_steps_records_duration() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1463,6 +1505,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         // Duration should be very small but non-zero
@@ -1480,8 +1523,8 @@ mod tests {
         assert!(!StepResult::ProviderFailed("x".to_string()).is_pass());
     }
 
-    #[test]
-    fn execute_steps_multiple_text_chunks_concatenated() {
+    #[tokio::test]
+    async fn execute_steps_multiple_text_chunks_concatenated() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1505,6 +1548,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.all_passed);
@@ -1563,8 +1607,8 @@ mod tests {
 
     // --- BUGATTI_LOG in execution tests ---
 
-    #[test]
-    fn execute_steps_captures_log_events() {
+    #[tokio::test]
+    async fn execute_steps_captures_log_events() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1588,6 +1632,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.all_passed);
@@ -1598,8 +1643,8 @@ mod tests {
         assert_eq!(outcome.steps[0].log_events[1].message, "Schema validated");
     }
 
-    #[test]
-    fn execute_steps_no_log_events() {
+    #[tokio::test]
+    async fn execute_steps_no_log_events() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1621,6 +1666,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.steps[0].log_events.is_empty());
@@ -1629,8 +1675,8 @@ mod tests {
         assert!(!log_events_path.exists());
     }
 
-    #[test]
-    fn execute_steps_writes_log_events_file() {
+    #[tokio::test]
+    async fn execute_steps_writes_log_events_file() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1654,6 +1700,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         // Log events file should exist and be separate from transcript
@@ -1670,8 +1717,8 @@ mod tests {
 
     // --- Evidence ref tests ---
 
-    #[test]
-    fn execute_steps_evidence_refs_for_error() {
+    #[tokio::test]
+    async fn execute_steps_evidence_refs_for_error() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1695,6 +1742,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert_eq!(outcome.steps[0].evidence_refs.len(), 1);
@@ -1705,8 +1753,8 @@ mod tests {
         assert!(outcome.steps[0].evidence_refs[0].collection_error.is_none());
     }
 
-    #[test]
-    fn execute_steps_evidence_refs_for_warn() {
+    #[tokio::test]
+    async fn execute_steps_evidence_refs_for_warn() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1728,13 +1776,14 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert_eq!(outcome.steps[0].evidence_refs.len(), 1);
     }
 
-    #[test]
-    fn execute_steps_evidence_refs_empty_for_ok() {
+    #[tokio::test]
+    async fn execute_steps_evidence_refs_empty_for_ok() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1756,6 +1805,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.steps[0].evidence_refs.is_empty());
@@ -1875,8 +1925,8 @@ mod tests {
         assert!(!content.contains("Base URL"));
     }
 
-    #[test]
-    fn execute_steps_with_bootstrap_writes_transcript() {
+    #[tokio::test]
+    async fn execute_steps_with_bootstrap_writes_transcript() {
         let steps = vec![test_steps().remove(0)];
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1906,6 +1956,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         // Bootstrap transcript file should exist
@@ -1920,8 +1971,8 @@ mod tests {
 
     // --- Interrupt tests ---
 
-    #[test]
-    fn execute_steps_interrupted_between_steps() {
+    #[tokio::test]
+    async fn execute_steps_interrupted_between_steps() {
         let steps = test_steps(); // 2 steps
         let (run_id, session_id) = test_run_ids();
         let (_tmp, artifact_dir) = test_artifact_dir();
@@ -1956,6 +2007,7 @@ mod tests {
             std::path::Path::new("."),
             &flag,
         )
+        .await
         .unwrap();
 
         // No steps should have executed
@@ -1966,8 +2018,8 @@ mod tests {
 
     // --- Setup step tests ---
 
-    #[test]
-    fn setup_step_tolerates_missing_result_marker() {
+    #[tokio::test]
+    async fn setup_step_tolerates_missing_result_marker() {
         let steps = vec![ExpandedStep {
             step_id: 0,
             instruction: "Start the browser in headed mode".to_string(),
@@ -2002,6 +2054,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.all_passed);
@@ -2013,8 +2066,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn setup_step_bypasses_skip() {
+    #[tokio::test]
+    async fn setup_step_bypasses_skip() {
         let steps = vec![
             ExpandedStep {
                 step_id: 0,
@@ -2077,6 +2130,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(outcome.all_passed);
@@ -2099,8 +2153,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn setup_step_not_counted_in_all_passed() {
+    #[tokio::test]
+    async fn setup_step_not_counted_in_all_passed() {
         // A setup step + a failing test step: all_passed should be false
         // because the test step failed, not because of the setup step.
         let steps = vec![
@@ -2155,6 +2209,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         assert!(!outcome.all_passed);
@@ -2170,8 +2225,8 @@ mod tests {
         assert!(outcome.steps[1].result.is_failure());
     }
 
-    #[test]
-    fn setup_step_failure_aborts_run() {
+    #[tokio::test]
+    async fn setup_step_failure_aborts_run() {
         let steps = vec![
             ExpandedStep {
                 step_id: 0,
@@ -2222,6 +2277,7 @@ mod tests {
             std::path::Path::new("."),
             &AtomicBool::new(false),
         )
+        .await
         .unwrap();
 
         // Only the setup step executed, and it failed

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,8 @@ struct TestRunResult {
     error: Option<String>,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // Install Ctrl+C handler for graceful interruption.
     // The handler sets a flag; the run loop checks it between steps.
     let interrupted = Arc::new(AtomicBool::new(false));
@@ -149,7 +150,7 @@ fn main() {
     let is_update_command = matches!(&cli.command, Commands::Update { .. });
 
     let code = match cli.command {
-        Commands::Update { check, yes } => match bugatti::update::run_update(check, yes) {
+        Commands::Update { check, yes } => match bugatti::update::run_update(check, yes).await {
             Ok(()) => EXIT_OK,
             Err(e) => {
                 eprintln!("ERROR: {e}");
@@ -186,7 +187,8 @@ fn main() {
                             from_checkpoint.as_deref(),
                             verbose,
                             explicit_config.as_deref(),
-                        );
+                        )
+                        .await;
                         // Print run reference for single-file mode
                         if let Some(run_id) = &result.run_id {
                             println!("\nRun ID: {run_id}");
@@ -216,22 +218,25 @@ fn main() {
                         EXIT_CONFIG_ERROR
                     }
                 },
-                None => run_discovery(
-                    &project_root,
-                    &skip_cmds,
-                    &skip_readiness,
-                    strict_warnings,
-                    from_checkpoint.as_deref(),
-                    verbose,
-                    explicit_config.as_deref(),
-                ),
+                None => {
+                    run_discovery(
+                        &project_root,
+                        &skip_cmds,
+                        &skip_readiness,
+                        strict_warnings,
+                        from_checkpoint.as_deref(),
+                        verbose,
+                        explicit_config.as_deref(),
+                    )
+                    .await
+                }
             }
         }
     };
 
-    // Passive background version check after successful runs
+    // Passive version check after successful runs
     if code == EXIT_OK && !is_update_command {
-        bugatti::update::spawn_passive_check();
+        bugatti::update::run_passive_check().await;
     }
 
     std::process::exit(code);
@@ -242,7 +247,7 @@ fn main() {
 /// Pipeline order: config load -> parse -> expand -> artifact setup -> command setup
 /// -> provider init -> step execution -> report -> teardown -> exit
 #[allow(clippy::too_many_arguments)]
-fn run_test_pipeline(
+async fn run_test_pipeline(
     project_root: &Path,
     test_path: &Path,
     skip_cmds: &[String],
@@ -369,7 +374,7 @@ fn run_test_pipeline(
         start_time: chrono::Utc::now(),
         verbose,
     };
-    run_test_with_artifacts(&ctx, steps)
+    run_test_with_artifacts(&ctx, steps).await
 }
 
 /// State shared across the pipeline after artifact setup.
@@ -392,13 +397,13 @@ struct PipelineContext<'a> {
 
 impl<'a> PipelineContext<'a> {
     /// Build a TestRunResult for a pre-execution failure, writing a best-effort report.
-    fn fail_early(
+    async fn fail_early(
         &self,
         exit_code: i32,
         error: String,
         tracked: &mut [TrackedProcess],
     ) -> TestRunResult {
-        command::teardown_processes(tracked);
+        command::teardown_processes(tracked).await;
         let end_time = chrono::Utc::now();
         let empty_outcome = executor::RunOutcome {
             steps: vec![],
@@ -452,8 +457,8 @@ impl<'a> PipelineContext<'a> {
 
 /// Continue the pipeline after artifact setup. Ensures best-effort report writing
 /// and subprocess teardown even on failure.
-fn run_test_with_artifacts(
-    ctx: &PipelineContext,
+async fn run_test_with_artifacts(
+    ctx: &PipelineContext<'_>,
     mut steps: Vec<bugatti::expand::ExpandedStep>,
 ) -> TestRunResult {
     // Phase 7: Initialize tracing
@@ -495,11 +500,13 @@ fn run_test_with_artifacts(
     if let Some(cp_name) = ctx.from_checkpoint {
         if ctx.effective.checkpoint.is_none() {
             let mut no_processes = vec![];
-            return ctx.fail_early(
-                EXIT_CONFIG_ERROR,
-                format!("--from-checkpoint \"{cp_name}\" requires a [checkpoint] section in bugatti.config.toml"),
-                &mut no_processes,
-            );
+            return ctx
+                .fail_early(
+                    EXIT_CONFIG_ERROR,
+                    format!("--from-checkpoint \"{cp_name}\" requires a [checkpoint] section in bugatti.config.toml"),
+                    &mut no_processes,
+                )
+                .await;
         }
         let cp_step_idx = steps
             .iter()
@@ -526,7 +533,9 @@ fn run_test_with_artifacts(
                         available.join(", ")
                     )
                 };
-                return ctx.fail_early(EXIT_CONFIG_ERROR, msg, &mut no_processes);
+                return ctx
+                    .fail_early(EXIT_CONFIG_ERROR, msg, &mut no_processes)
+                    .await;
             }
         }
     }
@@ -535,14 +544,16 @@ fn run_test_with_artifacts(
 
     // Phase 8: Run short-lived setup commands
     if let Err(e) =
-        command::run_short_lived_commands(ctx.effective, ctx.artifact_dir, ctx.skip_cmds)
+        command::run_short_lived_commands(ctx.effective, ctx.artifact_dir, ctx.skip_cmds).await
     {
         tracing::error!(error = %e, "short-lived command failed");
-        return ctx.fail_early(
-            EXIT_SETUP_ERROR,
-            format!("setup command failed: {e}"),
-            &mut no_processes,
-        );
+        return ctx
+            .fail_early(
+                EXIT_SETUP_ERROR,
+                format!("setup command failed: {e}"),
+                &mut no_processes,
+            )
+            .await;
     }
 
     // Phase 9: Spawn long-lived commands
@@ -551,15 +562,19 @@ fn run_test_with_artifacts(
         ctx.artifact_dir,
         ctx.skip_cmds,
         ctx.skip_readiness,
-    ) {
+    )
+    .await
+    {
         Ok(p) => p,
         Err(e) => {
             tracing::error!(error = %e, "long-lived command failed");
-            return ctx.fail_early(
-                EXIT_PROVIDER_ERROR,
-                format!("long-lived command failed: {e}"),
-                &mut no_processes,
-            );
+            return ctx
+                .fail_early(
+                    EXIT_PROVIDER_ERROR,
+                    format!("long-lived command failed: {e}"),
+                    &mut no_processes,
+                )
+                .await;
         }
     };
 
@@ -569,35 +584,41 @@ fn run_test_with_artifacts(
             Ok(s) => s,
             Err(e) => {
                 tracing::error!(error = %e, "provider initialization failed");
-                return ctx.fail_early(
-                    EXIT_PROVIDER_ERROR,
-                    provider_initialization_error_message(&e),
-                    &mut tracked_processes,
-                );
+                return ctx
+                    .fail_early(
+                        EXIT_PROVIDER_ERROR,
+                        provider_initialization_error_message(&e),
+                        &mut tracked_processes,
+                    )
+                    .await;
             }
         };
 
-    if let Err(e) = session.start() {
+    if let Err(e) = session.start().await {
         tracing::error!(error = %e, "provider start failed");
-        return ctx.fail_early(
-            EXIT_PROVIDER_ERROR,
-            format!("provider start failed: {e}"),
-            &mut tracked_processes,
-        );
+        return ctx
+            .fail_early(
+                EXIT_PROVIDER_ERROR,
+                format!("provider start failed: {e}"),
+                &mut tracked_processes,
+            )
+            .await;
     }
 
     // Phase 11: Check for unexpected exits before step execution
     if let Some((name, code)) = command::check_for_unexpected_exits(&mut tracked_processes) {
         tracing::error!(command = %name, exit_code = ?code, "long-lived process exited unexpectedly");
-        let _ = session.close();
+        let _ = session.close().await;
         let code_str = code
             .map(|c| c.to_string())
             .unwrap_or_else(|| "unknown".to_string());
-        return ctx.fail_early(
-            EXIT_PROVIDER_ERROR,
-            format!("long-lived process '{name}' exited unexpectedly (code: {code_str})"),
-            &mut tracked_processes,
-        );
+        return ctx
+            .fail_early(
+                EXIT_PROVIDER_ERROR,
+                format!("long-lived process '{name}' exited unexpectedly (code: {code_str})"),
+                &mut tracked_processes,
+            )
+            .await;
     }
 
     // Phase 12: Execute steps
@@ -624,26 +645,30 @@ fn run_test_with_artifacts(
         ctx.effective.checkpoint.as_ref(),
         ctx.project_root,
         &INTERRUPTED,
-    ) {
+    )
+    .await
+    {
         Ok(outcome) => outcome,
         Err(e) => {
             tracing::error!(error = %e, "step execution failed");
-            let _ = session.close();
-            return ctx.fail_early(
-                EXIT_STEP_ERROR,
-                format!("execution error: {e}"),
-                &mut tracked_processes,
-            );
+            let _ = session.close().await;
+            return ctx
+                .fail_early(
+                    EXIT_STEP_ERROR,
+                    format!("execution error: {e}"),
+                    &mut tracked_processes,
+                )
+                .await;
         }
     };
 
     // Phase 13: Close provider session
-    if let Err(e) = session.close() {
+    if let Err(e) = session.close().await {
         tracing::warn!(error = %e, "provider session close failed (non-fatal)");
     }
 
     // Phase 14: Teardown long-lived processes
-    let teardown_results = command::teardown_processes(&mut tracked_processes);
+    let teardown_results = command::teardown_processes(&mut tracked_processes).await;
     for td in &teardown_results {
         if !td.success {
             tracing::warn!(command = %td.name, message = %td.message, "teardown issue");
@@ -679,7 +704,7 @@ fn run_test_with_artifacts(
 
 /// Discover and run all root test files, printing an aggregate summary.
 /// Returns the aggregate exit code.
-fn run_discovery(
+async fn run_discovery(
     project_root: &Path,
     skip_cmds: &[String],
     skip_readiness: &[String],
@@ -746,7 +771,8 @@ fn run_discovery(
             from_checkpoint,
             verbose,
             explicit_config,
-        );
+        )
+        .await;
         results.push(result);
     }
 
@@ -773,7 +799,7 @@ fn run_discovery(
 
 /// Run a single discovered test file through the full pipeline.
 #[allow(clippy::too_many_arguments)]
-fn run_single_test(
+async fn run_single_test(
     test: &DiscoveredTest,
     project_root: &Path,
     skip_cmds: &[String],
@@ -796,7 +822,8 @@ fn run_single_test(
         from_checkpoint,
         verbose,
         explicit_config,
-    );
+    )
+    .await;
 
     if let Some(err) = &result.error {
         eprintln!("  ERROR: {err}");

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -1,12 +1,15 @@
 use crate::config::Config;
 use crate::provider::{
-    format_step_message, AgentSession, BootstrapMessage, OutputChunk, ProviderError, StepMessage,
+    format_step_message, AgentSession, BootstrapMessage, OutputChunk, OutputStream, ProviderError,
+    StepMessage, VecOutputStream,
 };
+use async_trait::async_trait;
 use serde::Deserialize;
-use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
-use std::time::{Duration, Instant};
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdout, Command};
 
 /// Compact base system prompt for the driving `pi` agent.
 ///
@@ -123,17 +126,19 @@ impl PiAdapter {
     }
 
     /// Spawn a single pi turn, sending `prompt` on stdin and streaming output.
-    fn spawn_turn(
+    async fn spawn_turn(
         &mut self,
         prompt: &str,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
         // Persist the bootstrap as an artifact for debugging. The return value
         // is intentionally unused for launching: pi receives the bootstrap as
         // inline content below, not as a path argument.
         let _bootstrap_path = self.ensure_bootstrap_file()?;
 
         let mut cmd = Command::new(&self.binary_path);
+        // If the stream is abandoned mid-turn (e.g. step timeout or Ctrl+C),
+        // make sure the pi subprocess doesn't linger.
+        cmd.kill_on_drop(true);
         cmd.arg("--print")
             .arg("--mode")
             .arg("json")
@@ -161,12 +166,13 @@ impl PiAdapter {
 
         if self.verbose {
             let args: Vec<_> = cmd
+                .as_std()
                 .get_args()
                 .map(|arg| arg.to_string_lossy().to_string())
                 .collect();
             eprintln!(
                 "\x1b[38;5;243m[verbose]\x1b[0m \x1b[38;5;243mlaunch:\x1b[0m \x1b[38;5;152m{} {}\x1b[0m",
-                cmd.get_program().to_string_lossy(),
+                cmd.as_std().get_program().to_string_lossy(),
                 args.join(" ")
             );
         }
@@ -181,9 +187,11 @@ impl PiAdapter {
             .ok_or_else(|| ProviderError::StartFailed("failed to capture stdin".to_string()))?;
         stdin
             .write_all(prompt.as_bytes())
+            .await
             .map_err(|e| ProviderError::SendFailed(format!("failed to write to stdin: {e}")))?;
         stdin
             .flush()
+            .await
             .map_err(|e| ProviderError::SendFailed(format!("failed to flush stdin: {e}")))?;
         drop(stdin);
 
@@ -194,7 +202,7 @@ impl PiAdapter {
 
         self.turn_index += 1;
 
-        Ok(Box::new(PiTurnIterator {
+        Ok(Box::new(PiTurnStream {
             child,
             reader: BufReader::new(stdout),
             verbose: self.verbose,
@@ -204,6 +212,7 @@ impl PiAdapter {
     }
 }
 
+#[async_trait]
 impl AgentSession for PiAdapter {
     fn initialize(
         config: &Config,
@@ -244,31 +253,29 @@ impl AgentSession for PiAdapter {
         })
     }
 
-    fn start(&mut self) -> Result<(), ProviderError> {
+    async fn start(&mut self) -> Result<(), ProviderError> {
         // Pi is spawned lazily per turn; nothing to start up front.
         Ok(())
     }
 
-    fn send_bootstrap(
+    async fn send_bootstrap(
         &mut self,
         message: BootstrapMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
         // Store bootstrap content — it is passed inline as --append-system-prompt on
         // every turn. No model call is made here.
         self.bootstrap_content = Some(message.content);
-        Ok(Box::new(std::iter::once(Ok(OutputChunk::Done))))
+        Ok(Box::new(VecOutputStream::done()))
     }
 
-    fn send_step(
+    async fn send_step(
         &mut self,
         message: StepMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
-        self.spawn_turn(&format_step_message(&message))
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
+        self.spawn_turn(&format_step_message(&message)).await
     }
 
-    fn close(&mut self) -> Result<(), ProviderError> {
+    async fn close(&mut self) -> Result<(), ProviderError> {
         // Each turn is a short-lived process that has already exited; nothing
         // long-lived to tear down.
         tracing::info!("closing pi session");
@@ -276,12 +283,14 @@ impl AgentSession for PiAdapter {
     }
 }
 
-/// Iterator that reads one turn of streamed output from a pi subprocess.
+/// Stream that reads one turn of streamed output from a pi subprocess.
 ///
 /// Parses JSONL from stdout, emitting `OutputChunk::Text` for streamed text
 /// deltas and `OutputChunk::Done` once the turn finishes. Provider errors are
 /// surfaced via the `errorMessage`/`stopReason` fields on turn/message events.
-struct PiTurnIterator {
+/// The subprocess is spawned with `kill_on_drop`, so abandoning the stream
+/// mid-turn (step timeout, Ctrl+C) cannot leak a lingering pi process.
+struct PiTurnStream {
     child: Child,
     reader: BufReader<ChildStdout>,
     verbose: bool,
@@ -293,67 +302,45 @@ struct PiTurnIterator {
 /// logically completed, before force-killing it.
 const TURN_EXIT_GRACE: Duration = Duration::from_secs(2);
 
-impl PiTurnIterator {
+impl PiTurnStream {
     /// Reap the turn subprocess after the turn has logically completed.
     ///
     /// pi 0.80.x keeps the `--print` process alive after emitting the terminal
-    /// `agent_end` event (issue #48), so a plain blocking `wait()` here hangs
+    /// `agent_end` event (issue #48), so waiting without a bound here hangs
     /// until the step timeout fires. The turn is semantically finished once
     /// `agent_end` arrives (the session transcript is already flushed), so
     /// give the process a short grace period to exit cleanly, then kill it.
     ///
     /// Returns the exit status if the process exited on its own, or `None` if
     /// it had to be killed.
-    fn reap_child(&mut self) -> Option<ExitStatus> {
-        let deadline = Instant::now() + TURN_EXIT_GRACE;
-        loop {
-            match self.child.try_wait() {
-                Ok(Some(status)) => return Some(status),
-                Ok(None) => {
-                    if Instant::now() >= deadline {
-                        break;
-                    }
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-                Err(_) => break,
-            }
+    async fn reap_child(&mut self) -> Option<ExitStatus> {
+        if let Ok(Ok(status)) = tokio::time::timeout(TURN_EXIT_GRACE, self.child.wait()).await {
+            return Some(status);
         }
         tracing::debug!("pi turn process still alive after turn completion; killing it");
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        let _ = self.child.start_kill();
+        let _ = self.child.wait().await;
         None
     }
 }
 
-impl Drop for PiTurnIterator {
-    fn drop(&mut self) {
-        // If the iterator is abandoned mid-turn (e.g. step timeout or Ctrl+C),
-        // make sure the pi subprocess doesn't linger.
-        if let Ok(None) = self.child.try_wait() {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
-        }
-    }
-}
-
-impl Iterator for PiTurnIterator {
-    type Item = Result<OutputChunk, ProviderError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
+#[async_trait]
+impl OutputStream for PiTurnStream {
+    async fn next_chunk(&mut self) -> Option<Result<OutputChunk, ProviderError>> {
         if self.done {
             return None;
         }
 
         loop {
             let mut line = String::new();
-            match self.reader.read_line(&mut line) {
+            match self.reader.read_line(&mut line).await {
                 Ok(0) => {
                     // EOF — the turn's output stream is finished. The process
                     // has usually exited, but don't block forever if it hasn't
                     // (pi 0.80.x can keep running after closing stdout).
                     self.done = true;
 
-                    let status = self.reap_child();
+                    let status = self.reap_child().await;
 
                     if let Some(message) = self.latest_error.take() {
                         return Some(Err(ProviderError::StreamError(message)));
@@ -440,7 +427,7 @@ impl Iterator for PiTurnIterator {
                             if let Some(message) = self.latest_error.take() {
                                 return Some(Err(ProviderError::StreamError(message)));
                             }
-                            let _ = self.reap_child();
+                            let _ = self.reap_child().await;
                             return Some(Ok(OutputChunk::Done));
                         }
                         _ => continue,
@@ -465,6 +452,7 @@ mod tests {
     use indexmap::IndexMap;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
+    use std::time::Instant;
 
     fn test_config() -> Config {
         Config {
@@ -593,11 +581,11 @@ exit 0
         }
     }
 
-    fn collect_output(
-        stream: Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>,
+    async fn collect_output(
+        mut stream: Box<dyn OutputStream + '_>,
     ) -> Result<String, ProviderError> {
         let mut output = String::new();
-        for item in stream {
+        while let Some(item) = stream.next_chunk().await {
             match item? {
                 OutputChunk::Text(text) => output.push_str(&text),
                 OutputChunk::Done => break,
@@ -606,8 +594,8 @@ exit 0
         Ok(output)
     }
 
-    #[test]
-    fn send_step_streams_text_deltas() {
+    #[tokio::test]
+    async fn send_step_streams_text_deltas() {
         let tmp = tempfile::tempdir().unwrap();
         let artifact_dir = tmp.path().join("artifacts");
         fs::create_dir_all(&artifact_dir).unwrap();
@@ -623,16 +611,18 @@ exit 0
                     source_file: "tests/login.test.toml".to_string(),
                     instruction: "Verify the login form works".to_string(),
                 })
+                .await
                 .unwrap(),
         )
+        .await
         .unwrap();
 
         assert_eq!(output, "RESULT: OK");
         assert_eq!(adapter.turn_index, 1);
     }
 
-    #[test]
-    fn send_step_completes_when_pi_process_lingers_after_agent_end() {
+    #[tokio::test]
+    async fn send_step_completes_when_pi_process_lingers_after_agent_end() {
         // Regression test for issue #48: pi 0.80.x keeps the --print process
         // alive after emitting agent_end. The adapter must still deliver Done
         // promptly instead of blocking in wait() until the step timeout.
@@ -652,8 +642,10 @@ exit 0
                     source_file: "tests/login.test.toml".to_string(),
                     instruction: "Verify the login form works".to_string(),
                 })
+                .await
                 .unwrap(),
         )
+        .await
         .unwrap();
 
         assert_eq!(output, "RESULT OK");
@@ -666,8 +658,8 @@ exit 0
         );
     }
 
-    #[test]
-    fn send_bootstrap_stores_content_without_calling_model() {
+    #[tokio::test]
+    async fn send_bootstrap_stores_content_without_calling_model() {
         let tmp = tempfile::tempdir().unwrap();
         let artifact_dir = tmp.path().join("artifacts");
         fs::create_dir_all(&artifact_dir).unwrap();
@@ -680,8 +672,10 @@ exit 0
                     session_id: SessionId("sess-1".to_string()),
                     content: "Harness instructions".to_string(),
                 })
+                .await
                 .unwrap(),
         )
+        .await
         .unwrap();
 
         assert_eq!(output, "");
@@ -692,8 +686,8 @@ exit 0
         assert_eq!(adapter.turn_index, 0);
     }
 
-    #[test]
-    fn bootstrap_file_written_on_first_turn() {
+    #[tokio::test]
+    async fn bootstrap_file_written_on_first_turn() {
         let tmp = tempfile::tempdir().unwrap();
         let artifact_dir = tmp.path().join("artifacts");
         fs::create_dir_all(&artifact_dir).unwrap();
@@ -710,8 +704,10 @@ exit 0
                     source_file: "tests/x.test.toml".to_string(),
                     instruction: "do it".to_string(),
                 })
+                .await
                 .unwrap(),
         )
+        .await
         .unwrap();
 
         let bootstrap_file = artifact_dir.join("pi_bootstrap_prompt.txt");
@@ -722,8 +718,8 @@ exit 0
         );
     }
 
-    #[test]
-    fn bootstrap_passed_as_content_with_base_system_prompt() {
+    #[tokio::test]
+    async fn bootstrap_passed_as_content_with_base_system_prompt() {
         // Regression for issue #47: pi must receive the bootstrap *content*
         // (carrying the RESULT-marker protocol) via --append-system-prompt,
         // alongside an explicit base --system-prompt so the appended protocol
@@ -748,8 +744,10 @@ exit 0
                     source_file: "tests/x.test.toml".to_string(),
                     instruction: "do it".to_string(),
                 })
+                .await
                 .unwrap(),
         )
+        .await
         .unwrap();
 
         let recorded = fs::read_to_string(&args_out).unwrap();
@@ -796,8 +794,8 @@ exit 0
         );
     }
 
-    #[test]
-    fn error_event_surfaces_stream_error() {
+    #[tokio::test]
+    async fn error_event_surfaces_stream_error() {
         let tmp = tempfile::tempdir().unwrap();
         let artifact_dir = tmp.path().join("artifacts");
         fs::create_dir_all(&artifact_dir).unwrap();
@@ -813,8 +811,10 @@ exit 0
                     source_file: "tests/x.test.toml".to_string(),
                     instruction: "do it".to_string(),
                 })
+                .await
                 .unwrap(),
-        );
+        )
+        .await;
 
         assert!(
             matches!(result, Err(ProviderError::StreamError(ref msg)) if msg == "model not found"),

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::run::{RunId, SessionId};
+use async_trait::async_trait;
 use std::path::Path;
 
 /// A message sent to the provider for a single step.
@@ -39,11 +40,57 @@ pub enum OutputChunk {
     Done,
 }
 
+/// An asynchronous stream of output chunks from the provider for one turn.
+///
+/// This is the async replacement for the previous `Iterator<Item = Result<OutputChunk, _>>`
+/// streaming interface: callers repeatedly await `next_chunk` until it returns `None`
+/// (stream exhausted) or an `OutputChunk::Done` is yielded (turn complete).
+#[async_trait]
+pub trait OutputStream: Send {
+    /// Await the next chunk of output. Returns `None` when the stream is exhausted.
+    async fn next_chunk(&mut self) -> Option<Result<OutputChunk, ProviderError>>;
+}
+
+/// An `OutputStream` backed by a pre-collected list of chunks.
+///
+/// Useful for providers that complete a turn without streaming (e.g. bootstrap
+/// handling that makes no model call) and for tests.
+pub struct VecOutputStream {
+    chunks: std::vec::IntoIter<Result<OutputChunk, ProviderError>>,
+}
+
+impl VecOutputStream {
+    /// Create a stream that yields the given chunks in order.
+    pub fn new(chunks: Vec<Result<OutputChunk, ProviderError>>) -> Self {
+        Self {
+            chunks: chunks.into_iter(),
+        }
+    }
+
+    /// Create a stream that yields a single `OutputChunk::Done`.
+    pub fn done() -> Self {
+        Self::new(vec![Ok(OutputChunk::Done)])
+    }
+
+    /// Create an empty stream.
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+#[async_trait]
+impl OutputStream for VecOutputStream {
+    async fn next_chunk(&mut self) -> Option<Result<OutputChunk, ProviderError>> {
+        self.chunks.next()
+    }
+}
+
 /// Provider-agnostic trait representing one long-lived agent session.
 ///
 /// The harness uses this trait to communicate with any provider (Claude Code, etc.)
 /// without coupling to provider-specific details. One session spans the entire test run.
-pub trait AgentSession {
+#[async_trait]
+pub trait AgentSession: Send {
     /// Initialize a new session from the effective config.
     ///
     /// The config has already been resolved (global + per-test overrides merged).
@@ -62,31 +109,31 @@ pub trait AgentSession {
     /// Start the conversation / underlying process.
     ///
     /// Called once after initialization, before any messages are sent.
-    fn start(&mut self) -> Result<(), ProviderError>;
+    async fn start(&mut self) -> Result<(), ProviderError>;
 
     /// Send a bootstrap message at the beginning of the session.
     ///
     /// This delivers harness instructions, extra system prompt, and context
     /// before any test steps execute. The provider streams its response
-    /// through the returned iterator.
-    fn send_bootstrap(
+    /// through the returned stream.
+    async fn send_bootstrap(
         &mut self,
         message: BootstrapMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>;
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError>;
 
     /// Send a step message and receive streamed output.
     ///
     /// The message includes run ID, session ID, and step ID for traceability.
-    /// Returns an iterator of output chunks for live display and transcript capture.
-    fn send_step(
+    /// Returns a stream of output chunks for live display and transcript capture.
+    async fn send_step(
         &mut self,
         message: StepMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>;
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError>;
 
     /// Close the session and clean up resources.
     ///
     /// Called at the end of a run (success or failure) to shut down the provider process.
-    fn close(&mut self) -> Result<(), ProviderError>;
+    async fn close(&mut self) -> Result<(), ProviderError>;
 }
 
 /// Format a step message with metadata prefix for sending to the provider.

--- a/src/update.rs
+++ b/src/update.rs
@@ -73,8 +73,8 @@ struct ReleaseMetadata {
 /// Sends a GET to the releases/latest URL with redirect following disabled.
 /// GitHub returns a 302 with `Location: .../releases/tag/v0.4.1` — we extract
 /// the tag from that header. One request, unlimited rate, no API token.
-fn discover_latest_tag(url: &str, timeout: Duration) -> Result<String, String> {
-    let client = reqwest::blocking::Client::builder()
+async fn discover_latest_tag(url: &str, timeout: Duration) -> Result<String, String> {
+    let client = reqwest::Client::builder()
         .user_agent(USER_AGENT)
         .timeout(timeout)
         .redirect(reqwest::redirect::Policy::none())
@@ -84,6 +84,7 @@ fn discover_latest_tag(url: &str, timeout: Duration) -> Result<String, String> {
     let response = client
         .get(url)
         .send()
+        .await
         .map_err(|e| format!("failed to connect to release server: {e}"))?;
 
     let status = response.status();
@@ -135,8 +136,8 @@ fn repo_base_from_url(url: &str) -> &str {
 }
 
 /// Fetches release metadata from the given URL.
-fn check_latest_version(url: &str, timeout: Duration) -> Result<ReleaseMetadata, String> {
-    let tag = discover_latest_tag(url, timeout)?;
+async fn check_latest_version(url: &str, timeout: Duration) -> Result<ReleaseMetadata, String> {
+    let tag = discover_latest_tag(url, timeout).await?;
     let repo_base = repo_base_from_url(url);
     Ok(build_release_metadata(&tag, repo_base))
 }
@@ -146,8 +147,8 @@ fn check_latest_version(url: &str, timeout: Duration) -> Result<ReleaseMetadata,
 // ---------------------------------------------------------------------------
 
 /// Downloads a URL to a file in the given directory.
-fn download_to_file(url: &str, dest_dir: &Path, filename: &str) -> Result<PathBuf, String> {
-    let client = reqwest::blocking::Client::builder()
+async fn download_to_file(url: &str, dest_dir: &Path, filename: &str) -> Result<PathBuf, String> {
+    let client = reqwest::Client::builder()
         .user_agent(USER_AGENT)
         .timeout(Duration::from_secs(120))
         .build()
@@ -156,6 +157,7 @@ fn download_to_file(url: &str, dest_dir: &Path, filename: &str) -> Result<PathBu
     let response = client
         .get(url)
         .send()
+        .await
         .map_err(|e| format!("failed to download '{filename}': {e}"))?;
 
     let status = response.status();
@@ -167,10 +169,13 @@ fn download_to_file(url: &str, dest_dir: &Path, filename: &str) -> Result<PathBu
 
     let bytes = response
         .bytes()
+        .await
         .map_err(|e| format!("failed to read response for '{filename}': {e}"))?;
 
     let dest_path = dest_dir.join(filename);
-    std::fs::write(&dest_path, &bytes).map_err(|e| format!("failed to write '{filename}': {e}"))?;
+    tokio::fs::write(&dest_path, &bytes)
+        .await
+        .map_err(|e| format!("failed to write '{filename}': {e}"))?;
 
     Ok(dest_path)
 }
@@ -358,18 +363,18 @@ fn confirm_update(local: &str, remote: &str) -> bool {
 ///
 /// If `check` is true, only prints whether an update is available.
 /// Otherwise, downloads, verifies, extracts, and replaces the running binary.
-pub fn run_update(check: bool, yes: bool) -> Result<(), String> {
+pub async fn run_update(check: bool, yes: bool) -> Result<(), String> {
     if check {
-        return run_update_check();
+        return run_update_check().await;
     }
-    run_update_install(yes)
+    run_update_install(yes).await
 }
 
 /// Check-only: prints whether an update is available.
-fn run_update_check() -> Result<(), String> {
+async fn run_update_check() -> Result<(), String> {
     let local = current_version();
 
-    let release = match check_latest_version(GITHUB_RELEASES_LATEST_URL, REQUEST_TIMEOUT) {
+    let release = match check_latest_version(GITHUB_RELEASES_LATEST_URL, REQUEST_TIMEOUT).await {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Warning: unable to check for updates: {e}");
@@ -396,11 +401,12 @@ fn run_update_check() -> Result<(), String> {
 }
 
 /// Full install: download, verify, extract, secure, replace.
-fn run_update_install(yes: bool) -> Result<(), String> {
+async fn run_update_install(yes: bool) -> Result<(), String> {
     let local = current_version();
 
     // Step 1: Fetch release metadata
     let release = check_latest_version(GITHUB_RELEASES_LATEST_URL, REQUEST_TIMEOUT)
+        .await
         .map_err(|e| format!("failed to check for latest release: {e}"))?;
 
     let remote = normalize_version_tag(&release.tag);
@@ -428,6 +434,7 @@ fn run_update_install(yes: bool) -> Result<(), String> {
 
     let checksums_path =
         download_to_file(&release.checksums_url, tmp_dir.path(), CHECKSUMS_FILENAME)
+            .await
             .map_err(|e| format!("failed to download checksums: {e}"))?;
 
     let artifact_name = release
@@ -436,6 +443,7 @@ fn run_update_install(yes: bool) -> Result<(), String> {
         .next()
         .unwrap_or("artifact.tar.gz");
     let artifact_path = download_to_file(&release.artifact_url, tmp_dir.path(), artifact_name)
+        .await
         .map_err(|e| format!("failed to download release: {e}"))?;
 
     // Step 5: Verify checksum
@@ -537,14 +545,15 @@ fn format_update_notification(current: &str, latest: &str) -> String {
     format!("\nUpdate available: v{current} → v{latest} — run `bugatti update` to install")
 }
 
-/// Performs the passive version check (called on a background thread).
-fn passive_version_check() {
+/// Performs the passive version check.
+async fn passive_version_check() {
     if !should_check_for_update() {
         return;
     }
 
     // Always update timestamp after attempt (prevents retry storms)
-    let check_result = check_latest_version(GITHUB_RELEASES_LATEST_URL, PASSIVE_CHECK_TIMEOUT);
+    let check_result =
+        check_latest_version(GITHUB_RELEASES_LATEST_URL, PASSIVE_CHECK_TIMEOUT).await;
     write_last_check_timestamp();
 
     let release = match check_result {
@@ -560,13 +569,9 @@ fn passive_version_check() {
     }
 }
 
-/// Spawns the passive version check on a background thread with a timeout.
-///
-/// Waits at most 3 seconds for the check to complete. If it doesn't finish,
-/// the thread is abandoned (it dies when the process exits).
-pub fn spawn_passive_check() {
-    let handle = std::thread::spawn(passive_version_check);
-    let _ = handle.join(); // join will wait; the HTTP timeout (3s) is the real bound
+/// Runs the passive version check, bounded by the passive HTTP timeout (3s).
+pub async fn run_passive_check() {
+    passive_version_check().await;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/pipeline_integration.rs
+++ b/tests/pipeline_integration.rs
@@ -12,7 +12,10 @@ use bugatti::diagnostics;
 use bugatti::executor::{self, RunOutcome, StepOutcome, StepResult, StepVerdict};
 use bugatti::exit_code;
 use bugatti::expand;
-use bugatti::provider::{AgentSession, BootstrapMessage, OutputChunk, ProviderError, StepMessage};
+use bugatti::provider::{
+    AgentSession, BootstrapMessage, OutputChunk, OutputStream, ProviderError, StepMessage,
+    VecOutputStream,
+};
 use bugatti::report::{self, ReportInput};
 use bugatti::run::{self, EffectiveConfigSummary};
 use bugatti::test_file;
@@ -41,6 +44,7 @@ impl MockProvider {
     }
 }
 
+#[async_trait::async_trait]
 impl AgentSession for MockProvider {
     fn initialize(
         _config: &Config,
@@ -53,53 +57,45 @@ impl AgentSession for MockProvider {
         Ok(Self::with_ok_responses(0))
     }
 
-    fn start(&mut self) -> Result<(), ProviderError> {
+    async fn start(&mut self) -> Result<(), ProviderError> {
         Ok(())
     }
 
-    fn send_bootstrap(
+    async fn send_bootstrap(
         &mut self,
         _message: BootstrapMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
-        Ok(Box::new(
-            vec![
-                Ok(OutputChunk::Text("Bootstrap acknowledged.\n".to_string())),
-                Ok(OutputChunk::Done),
-            ]
-            .into_iter(),
-        ))
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
+        Ok(Box::new(VecOutputStream::new(vec![
+            Ok(OutputChunk::Text("Bootstrap acknowledged.\n".to_string())),
+            Ok(OutputChunk::Done),
+        ])))
     }
 
-    fn send_step(
+    async fn send_step(
         &mut self,
         _message: StepMessage,
-    ) -> Result<Box<dyn Iterator<Item = Result<OutputChunk, ProviderError>> + '_>, ProviderError>
-    {
+    ) -> Result<Box<dyn OutputStream + '_>, ProviderError> {
         if self.call_count < self.responses.len() {
             let idx = self.call_count;
             self.call_count += 1;
-            Ok(Box::new(self.responses[idx].clone().into_iter()))
+            Ok(Box::new(VecOutputStream::new(self.responses[idx].clone())))
         } else {
-            Ok(Box::new(
-                vec![
-                    Ok(OutputChunk::Text("RESULT OK\n".to_string())),
-                    Ok(OutputChunk::Done),
-                ]
-                .into_iter(),
-            ))
+            Ok(Box::new(VecOutputStream::new(vec![
+                Ok(OutputChunk::Text("RESULT OK\n".to_string())),
+                Ok(OutputChunk::Done),
+            ])))
         }
     }
 
-    fn close(&mut self) -> Result<(), ProviderError> {
+    async fn close(&mut self) -> Result<(), ProviderError> {
         Ok(())
     }
 }
 
 /// Test the full pipeline with a mock provider: config -> parse -> expand ->
 /// artifacts -> execution -> report -> exit code.
-#[test]
-fn full_pipeline_with_mock_provider() {
+#[tokio::test]
+async fn full_pipeline_with_mock_provider() {
     let tmp = tempfile::tempdir().unwrap();
     let project_root = tmp.path();
 
@@ -154,7 +150,7 @@ instruction = "Verify the login form is present"
 
     // Phase 10: Mock provider
     let mut session = MockProvider::with_ok_responses(2);
-    session.start().unwrap();
+    session.start().await.unwrap();
 
     // Phase 11: Execute steps
     let outcome = executor::execute_steps(
@@ -169,6 +165,7 @@ instruction = "Verify the login form is present"
         std::path::Path::new("."),
         &std::sync::atomic::AtomicBool::new(false),
     )
+    .await
     .unwrap();
 
     assert!(outcome.all_passed);
@@ -178,7 +175,7 @@ instruction = "Verify the login form is present"
     }
 
     // Phase 12: Close session
-    session.close().unwrap();
+    session.close().await.unwrap();
 
     // Phase 13: Write report
     let start_time = chrono::Utc::now();
@@ -266,8 +263,8 @@ include_path = "{}"
 }
 
 /// Test pipeline with a step that returns ERROR.
-#[test]
-fn pipeline_with_error_step_exits_nonzero() {
+#[tokio::test]
+async fn pipeline_with_error_step_exits_nonzero() {
     let tmp = tempfile::tempdir().unwrap();
     let project_root = tmp.path();
 
@@ -298,7 +295,7 @@ instruction = "This step will fail"
         ]],
         call_count: 0,
     };
-    session.start().unwrap();
+    session.start().await.unwrap();
 
     let outcome = executor::execute_steps(
         &mut session,
@@ -312,6 +309,7 @@ instruction = "This step will fail"
         std::path::Path::new("."),
         &std::sync::atomic::AtomicBool::new(false),
     )
+    .await
     .unwrap();
 
     assert!(!outcome.all_passed);


### PR DESCRIPTION
## Summary
- Convert provider sessions, command execution, and the update flow to Tokio async I/O
- Enforce streaming timeouts while waiting for each chunk and kill abandoned subprocesses on drop
- Update CHANGELOG.md

## Verification
- RUSTFLAGS='-D warnings' cargo check
- RUSTFLAGS='-D warnings' cargo clippy -- -D warnings
- RUSTFLAGS='-D warnings' cargo test