### PR TITLE
Enforce passive update check deadline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ test-support = []
 
 [dev-dependencies]
 bugatti = { path = ".", features = ["test-support"] }
+tokio = { version = "1", features = ["test-util"] }

--- a/src/update.rs
+++ b/src/update.rs
@@ -732,9 +732,18 @@ async fn passive_version_check() {
     }
 }
 
-/// Runs the passive version check, bounded by the passive HTTP timeout (3s).
+/// Awaits `fut` but abandons it after `deadline` elapses.
+async fn run_with_deadline<F: std::future::Future<Output = ()>>(fut: F, deadline: Duration) {
+    if tokio::time::timeout(deadline, fut).await.is_err() {
+        tracing::debug!("passive update check timed out; abandoning");
+    }
+}
+
+/// Runs the passive version check with a hard 3-second deadline.
+/// If the check doesn't finish in time it is dropped (cancelled); the
+/// process may then exit without completing it.
 pub async fn run_passive_check() {
-    passive_version_check().await;
+    run_with_deadline(passive_version_check(), PASSIVE_CHECK_TIMEOUT).await;
 }
 
 // ---------------------------------------------------------------------------
@@ -744,6 +753,25 @@ pub async fn run_passive_check() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn deadline_abandons_hung_future() {
+        // A future that never completes must not block past the deadline.
+        run_with_deadline(std::future::pending::<()>(), Duration::from_secs(3)).await;
+        // Reaching here proves the deadline fired (paused clock auto-advances).
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deadline_completes_fast_future() {
+        let flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let f2 = flag.clone();
+        run_with_deadline(
+            async move { f2.store(true, std::sync::atomic::Ordering::SeqCst) },
+            Duration::from_secs(3),
+        )
+        .await;
+        assert!(flag.load(std::sync::atomic::Ordering::SeqCst));
+    }
 
     #[test]
     fn normalize_strips_lowercase_v() {

--- a/src/update.rs
+++ b/src/update.rs
@@ -714,10 +714,14 @@ async fn passive_version_check() {
         return;
     }
 
-    // Always update timestamp after attempt (prevents retry storms)
+    // Record the attempt *before* the network call (prevents retry storms).
+    // The outer deadline in `run_passive_check` may cancel this future while
+    // the HTTP request is in flight; writing the timestamp first guarantees
+    // a hung network can't cause every subsequent run to retry (and pay the
+    // full deadline) again.
+    write_last_check_timestamp();
     let check_result =
         check_latest_version(GITHUB_RELEASES_LATEST_URL, PASSIVE_CHECK_TIMEOUT).await;
-    write_last_check_timestamp();
 
     let release = match check_result {
         Ok(r) => r,
@@ -757,8 +761,11 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn deadline_abandons_hung_future() {
         // A future that never completes must not block past the deadline.
+        let start = tokio::time::Instant::now();
         run_with_deadline(std::future::pending::<()>(), Duration::from_secs(3)).await;
-        // Reaching here proves the deadline fired (paused clock auto-advances).
+        // Paused clock auto-advances exactly to the deadline: reaching here
+        // proves the timeout fired, and the elapsed check pins its value.
+        assert_eq!(start.elapsed(), Duration::from_secs(3));
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary
- Wrap the entire passive update check in a hard 3-second Tokio timeout before process exit.
- Keep the public passive check entrypoint as a thin wrapper while adding a private deadline helper.
- Add paused-time async tests covering both hung and fast futures.
- Add Tokio `test-util` as a dev-only feature for deterministic deadline tests.

## Verification
- `RUSTFLAGS="-D warnings" cargo test` — passes
- `cargo test --lib update` — passes
- `cargo clippy --all-targets -- -D warnings` — passes
- `cargo fmt --check` — passes

Closes #36
